### PR TITLE
Add configuration for importing files from an absolute path

### DIFF
--- a/backend/jest.config.js
+++ b/backend/jest.config.js
@@ -6,6 +6,8 @@ const config = {
 	extensionsToTreatAsEsm: [".ts"], // used by the moduleNameMapper config property
 	moduleNameMapper: {
 		"^(\\.{1,2}/.*)\\.js$": "$1", // ts modules aren't detected without this. copied from: https://stackoverflow.com/a/69598249
+		"^#/(.*)$": "<rootDir>/$1",
+		"^#shared/(.*)$": "<rootDir>/../shared/$1",
 	},
 
 	collectCoverage: true,

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,5 +1,8 @@
 {
 	"type": "module",
+	"imports": {
+		"#/*": "./dist/backend/*"
+	},
 	"scripts": {
 		"jest": "npx jest",
 		"build": "tsc",

--- a/backend/src/endpoints/files.ts
+++ b/backend/src/endpoints/files.ts
@@ -1,7 +1,7 @@
 import {type Express} from "express";
 import {type Pool} from "pg";
-import {timestampedLog} from "../logging.js";
-import {UserFileSchema} from "../validation/schemas.js";
+import {timestampedLog} from "#/src/logging.js";
+import {UserFileSchema} from "#/src/validation/schemas.js";
 import z from "zod";
 
 const getFiles = (app: Express, db: Pool) => {

--- a/backend/src/validation/schemas.ts
+++ b/backend/src/validation/schemas.ts
@@ -1,4 +1,4 @@
-import {type Placeholder, type UserFile} from "../../../shared/src/types.js";
+import {type Placeholder, type UserFile} from "#shared/src/types.js";
 import {z, type ZodType} from "zod";
 
 export const placeholderSchema = z.string() satisfies ZodType<Placeholder>;

--- a/backend/tsconfig.json
+++ b/backend/tsconfig.json
@@ -1,5 +1,10 @@
 {
 	"compilerOptions": {
+		"baseUrl": ".",
+		"paths": {
+			"#/*": ["./*"],
+			"#shared/*": ["../shared/*"]
+		},
 		"target": "esnext",
 		"module": "nodenext",
 		"moduleResolution": "nodenext",

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -16,7 +16,7 @@ const compat = new FlatCompat({
 });
 
 export default defineConfig([
-	globalIgnores(["**/node_modules/", "**/playwright-report/"]),
+	globalIgnores(["**/node_modules/", "**/playwright-report/", "**/dist/"]),
 	{
 		extends: compat.extends("eslint:recommended", "plugin:@typescript-eslint/recommended"),
 

--- a/frontend/src/codeEditor/editor.page.tsx
+++ b/frontend/src/codeEditor/editor.page.tsx
@@ -1,6 +1,6 @@
 import CodeEditor from "./CodeEditor";
 import {useParams} from "react-router";
-import type {UserFile} from "../../../shared/src/types";
+import type {UserFile} from "#shared/src/types";
 import {useEffect, useState} from "react";
 
 export default function EditorPage() {

--- a/frontend/tsconfig.app.json
+++ b/frontend/tsconfig.app.json
@@ -1,5 +1,11 @@
 {
 	"compilerOptions": {
+		/* Import aliases setup */
+		"baseUrl": ".",
+		"paths": {
+			"#/*": ["./*"],
+			"#shared/*": ["../shared/*"]
+		},
 		"tsBuildInfoFile": "./node_modules/.tmp/tsconfig.app.tsbuildinfo",
 		"target": "ES2022",
 		"useDefineForClassFields": true,
@@ -7,7 +13,6 @@
 		"module": "ESNext",
 		"types": ["vite/client"],
 		"skipLibCheck": true,
-
 		/* Bundler mode */
 		"moduleResolution": "bundler",
 		"allowImportingTsExtensions": true,
@@ -15,7 +20,6 @@
 		"moduleDetection": "force",
 		"noEmit": true,
 		"jsx": "react-jsx",
-
 		/* Linting */
 		"strict": true,
 		"noUnusedLocals": true,

--- a/frontend/tsconfig.node.json
+++ b/frontend/tsconfig.node.json
@@ -1,19 +1,23 @@
 {
 	"compilerOptions": {
+		/* Import aliases setup */
+		"baseUrl": ".",
+		"paths": {
+			"#/*": ["./*"],
+			"#shared/*": ["../shared/*"]
+		},
 		"tsBuildInfoFile": "./node_modules/.tmp/tsconfig.node.tsbuildinfo",
 		"target": "ES2023",
 		"lib": ["ES2023"],
 		"module": "ESNext",
 		"types": ["node"],
 		"skipLibCheck": true,
-
 		/* Bundler mode */
 		"moduleResolution": "bundler",
 		"allowImportingTsExtensions": true,
 		"verbatimModuleSyntax": true,
 		"moduleDetection": "force",
 		"noEmit": true,
-
 		/* Linting */
 		"strict": true,
 		"noUnusedLocals": true,

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -1,8 +1,15 @@
 import {defineConfig} from "vite";
 import react from "@vitejs/plugin-react";
+import path from "node:path";
 
 // https://vite.dev/config/
 export default defineConfig({
+	resolve: {
+		alias: {
+			"#": path.resolve(__dirname, "./"),
+			"#shared": path.resolve(__dirname, "../shared"),
+		},
+	},
 	plugins: [
 		react({
 			babel: {

--- a/shared/jest.config.js
+++ b/shared/jest.config.js
@@ -6,6 +6,8 @@ const config = {
 	extensionsToTreatAsEsm: [".ts"], // used by the moduleNameMapper config property
 	moduleNameMapper: {
 		"^(\\.{1,2}/.*)\\.js$": "$1", // ts modules aren't detected without this. copied from: https://stackoverflow.com/a/69598249
+		"^#/(.*)$": "<rootDir>/$1",
+		"^#shared/(.*)$": "<rootDir>/../shared/$1",
 	},
 
 	collectCoverage: true,

--- a/shared/tsconfig.json
+++ b/shared/tsconfig.json
@@ -1,9 +1,12 @@
 {
 	"compilerOptions": {
+		"baseUrl": ".",
+		"paths": {
+			"#/*": ["./*"]
+		},
 		// no "target" because these always get compiled based on another folder's config
 		"module": "nodenext",
 		"lib": ["esnext"],
-
 		"strict": true,
 		"noUnusedLocals": true,
 		"noUnusedParameters": true,


### PR DESCRIPTION
This should let us avoid directory backtracking when importing into `.ts`/`.tsx` files, so the import routes would be simpler and less brittle.

Also, I included a small fix to our linting configuration. While working on this branch, I noticed that the linter (e.g. when we run `npm run SA`) would scan and complain about build-output files if those exist - it should no longer do that now.