### PR TITLE
Add `package.json` audit commands and fix audit issues

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -4,6 +4,7 @@
 	"requires": true,
 	"packages": {
 		"": {
+			"name": "backend",
 			"dependencies": {
 				"@codemirror/collab": "^6.1.1",
 				"@codemirror/state": "^6.6.0",
@@ -55,7 +56,6 @@
 			"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.0.tgz",
 			"integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
 			"dev": true,
-			"peer": true,
 			"dependencies": {
 				"@babel/code-frame": "^7.29.0",
 				"@babel/generator": "^7.29.0",
@@ -1794,9 +1794,9 @@
 			}
 		},
 		"node_modules/brace-expansion": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-			"integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.3.tgz",
+			"integrity": "sha512-MCV/fYJEbqx68aE58kv2cA/kiky1G8vux3OR6/jbS+jIMe/6fJWa0DTzJU7dqijOWYwHi1t29FlfYI9uytqlpA==",
 			"dev": true,
 			"dependencies": {
 				"balanced-match": "^1.0.0"
@@ -1833,7 +1833,6 @@
 					"url": "https://github.com/sponsors/ai"
 				}
 			],
-			"peer": true,
 			"dependencies": {
 				"baseline-browser-mapping": "^2.9.0",
 				"caniuse-lite": "^1.0.30001759",
@@ -2858,9 +2857,9 @@
 			"dev": true
 		},
 		"node_modules/handlebars": {
-			"version": "4.7.8",
-			"resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.8.tgz",
-			"integrity": "sha512-vafaFqs8MZkRrSX7sFVUdo3ap/eNiLnb4IakshzvP56X5Nr1iGKAIqdX6tMlm6HcNRIkr6AxO5jFEoJzzpT8aQ==",
+			"version": "4.7.9",
+			"resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.9.tgz",
+			"integrity": "sha512-4E71E0rpOaQuJR2A3xDZ+GM1HyWYv1clR58tC8emQNeQe3RH7MAzSbat+V0wG78LQBo6m6bzSG/L4pBuCsgnUQ==",
 			"dev": true,
 			"dependencies": {
 				"minimist": "^1.2.5",
@@ -3220,7 +3219,6 @@
 			"resolved": "https://registry.npmjs.org/jest/-/jest-30.3.0.tgz",
 			"integrity": "sha512-AkXIIFcaazymvey2i/+F94XRnM6TsVLZDhBMLsd1Sf/W0wzsvvpjeyUrCZD6HGG4SDYPgDJDBKeiJTBb10WzMg==",
 			"dev": true,
-			"peer": true,
 			"dependencies": {
 				"@jest/core": "30.3.0",
 				"@jest/types": "30.3.0",
@@ -3455,9 +3453,9 @@
 			}
 		},
 		"node_modules/jest-haste-map/node_modules/picomatch": {
-			"version": "4.0.3",
-			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-			"integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+			"version": "4.0.4",
+			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+			"integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
 			"dev": true,
 			"engines": {
 				"node": ">=12"
@@ -3515,9 +3513,9 @@
 			}
 		},
 		"node_modules/jest-message-util/node_modules/picomatch": {
-			"version": "4.0.3",
-			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-			"integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+			"version": "4.0.4",
+			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+			"integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
 			"dev": true,
 			"engines": {
 				"node": ">=12"
@@ -3714,9 +3712,9 @@
 			}
 		},
 		"node_modules/jest-util/node_modules/picomatch": {
-			"version": "4.0.3",
-			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-			"integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+			"version": "4.0.4",
+			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+			"integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
 			"dev": true,
 			"engines": {
 				"node": ">=12"
@@ -4181,9 +4179,9 @@
 			}
 		},
 		"node_modules/nodemon/node_modules/brace-expansion": {
-			"version": "5.0.4",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.4.tgz",
-			"integrity": "sha512-h+DEnpVvxmfVefa4jFbCf5HdH5YMDXRsmKflpf1pILZWRFlTbJpxeU55nJl4Smt5HQaGzg1o6RHFPJaOqnmBDg==",
+			"version": "5.0.5",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
+			"integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
 			"dev": true,
 			"dependencies": {
 				"balanced-match": "^4.0.2"
@@ -4423,9 +4421,9 @@
 			}
 		},
 		"node_modules/path-to-regexp": {
-			"version": "8.3.0",
-			"resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.3.0.tgz",
-			"integrity": "sha512-7jdwVIRtsP8MYpdXSwOS0YdD0Du+qOoF/AEPIt88PcCFrZCzx41oxku1jD88hZBwbNUIEfpqvuhjFaMAqMTWnA==",
+			"version": "8.4.2",
+			"resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
+			"integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
 			"funding": {
 				"type": "opencollective",
 				"url": "https://opencollective.com/express"
@@ -4436,7 +4434,6 @@
 			"resolved": "https://registry.npmjs.org/pg/-/pg-8.20.0.tgz",
 			"integrity": "sha512-ldhMxz2r8fl/6QkXnBD3CR9/xg694oT6DZQ2s6c/RI28OjtSOpxnPrUCGOBJ46RCUxcWdx3p6kw/xnDHjKvaRA==",
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"pg-connection-string": "^2.12.0",
 				"pg-pool": "^3.13.0",
@@ -4474,6 +4471,7 @@
 			"version": "2.19.0",
 			"resolved": "https://registry.npmjs.org/pg-cursor/-/pg-cursor-2.19.0.tgz",
 			"integrity": "sha512-J5cF1MUz7LRJ9emOqF/06QjabMHMZy587rSPF0UuA8rCwKeeYl2co8Pp+6k5UU9YrAYHMzWkLxilfZB0hqsWWw==",
+			"peer": true,
 			"peerDependencies": {
 				"pg": "^8"
 			}
@@ -4566,9 +4564,9 @@
 			"dev": true
 		},
 		"node_modules/picomatch": {
-			"version": "2.3.1",
-			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-			"integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+			"version": "2.3.2",
+			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+			"integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
 			"dev": true,
 			"engines": {
 				"node": ">=8.6"
@@ -5364,9 +5362,9 @@
 			}
 		},
 		"node_modules/test-exclude/node_modules/brace-expansion": {
-			"version": "1.1.12",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-			"integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+			"version": "1.1.13",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
+			"integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
 			"dev": true,
 			"dependencies": {
 				"balanced-match": "^1.0.0",
@@ -5561,7 +5559,6 @@
 			"resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
 			"integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
 			"dev": true,
-			"peer": true,
 			"bin": {
 				"tsc": "bin/tsc",
 				"tsserver": "bin/tsserver"

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1951,9 +1951,6 @@
 			"cpu": [
 				"arm64"
 			],
-			"libc": [
-				"glibc"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1969,9 +1966,6 @@
 			"integrity": "sha512-oCfG/mS+/+XRlwNjnsNLVwnMWYH7tn/kYPsNPh+JSOMlnt93mYNCKHYzylRhI51X+TbR+ufNhhKKzm6QkqX8ag==",
 			"cpu": [
 				"arm64"
-			],
-			"libc": [
-				"musl"
 			],
 			"license": "MIT",
 			"optional": true,
@@ -1989,9 +1983,6 @@
 			"cpu": [
 				"x64"
 			],
-			"libc": [
-				"glibc"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -2007,9 +1998,6 @@
 			"integrity": "sha512-XW3t3qwbIwiSyRCggeO2zxe3KWaEbM0/kW9e8+0XpBgyKU4ATYzcVSMKteZJ1iukJ3HgHBjbg9P5YPRCVUxlnQ==",
 			"cpu": [
 				"x64"
-			],
-			"libc": [
-				"musl"
 			],
 			"license": "MIT",
 			"optional": true,
@@ -2363,9 +2351,9 @@
 			}
 		},
 		"node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
-			"version": "5.0.4",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.4.tgz",
-			"integrity": "sha512-h+DEnpVvxmfVefa4jFbCf5HdH5YMDXRsmKflpf1pILZWRFlTbJpxeU55nJl4Smt5HQaGzg1o6RHFPJaOqnmBDg==",
+			"version": "5.0.5",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
+			"integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
 			"dev": true,
 			"dependencies": {
 				"balanced-match": "^4.0.2"
@@ -2559,9 +2547,9 @@
 			}
 		},
 		"node_modules/brace-expansion": {
-			"version": "1.1.12",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-			"integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+			"version": "1.1.13",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
+			"integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
 			"dev": true,
 			"dependencies": {
 				"balanced-match": "^1.0.0",
@@ -3480,9 +3468,6 @@
 			"cpu": [
 				"arm64"
 			],
-			"libc": [
-				"glibc"
-			],
 			"license": "MPL-2.0",
 			"optional": true,
 			"os": [
@@ -3502,9 +3487,6 @@
 			"integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
 			"cpu": [
 				"arm64"
-			],
-			"libc": [
-				"musl"
 			],
 			"license": "MPL-2.0",
 			"optional": true,
@@ -3526,9 +3508,6 @@
 			"cpu": [
 				"x64"
 			],
-			"libc": [
-				"glibc"
-			],
 			"license": "MPL-2.0",
 			"optional": true,
 			"os": [
@@ -3548,9 +3527,6 @@
 			"integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
 			"cpu": [
 				"x64"
-			],
-			"libc": [
-				"musl"
 			],
 			"license": "MPL-2.0",
 			"optional": true,
@@ -3773,9 +3749,9 @@
 			"integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="
 		},
 		"node_modules/picomatch": {
-			"version": "4.0.3",
-			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-			"integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+			"version": "4.0.4",
+			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+			"integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
 			"engines": {
 				"node": ">=12"
 			},
@@ -4174,9 +4150,9 @@
 			}
 		},
 		"node_modules/vite": {
-			"version": "7.3.1",
-			"resolved": "https://registry.npmjs.org/vite/-/vite-7.3.1.tgz",
-			"integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
+			"version": "7.3.2",
+			"resolved": "https://registry.npmjs.org/vite/-/vite-7.3.2.tgz",
+			"integrity": "sha512-Bby3NOsna2jsjfLVOHKes8sGwgl4TT0E6vvpYgnAYDIF/tie7MRaFthmKuHx1NSXjiTueXH3do80FMQgvEktRg==",
 			"dependencies": {
 				"esbuild": "^0.27.0",
 				"fdir": "^6.5.0",

--- a/package.json
+++ b/package.json
@@ -15,6 +15,8 @@
 		"prune": "docker builder prune -af && docker image prune -af && docker volume prune -af",
 		"re": "npm run fclean && npm run up",
 		"installAll": "npm install && cd shared && npm install && cd ../backend && npm install && cd ../frontend && npm install && cd ../testing && npm install",
+		"audit": "npm audit && cd shared && npm audit && cd ../backend && npm audit && cd ../frontend && npm audit && cd ../testing && npm audit",
+		"auditFix": "npm audit fix && cd shared && npm audit fix && cd ../backend && npm audit fix && cd ../frontend && npm audit fix && cd ../testing && npm audit fix",
 		"prettier": "npx prettier --write .",
 		"eslint": "npx eslint .",
 		"githook": "chmod +x scripts/pre-push-hook && cp scripts/pre-push-hook .git/hooks/pre-push"

--- a/shared/package-lock.json
+++ b/shared/package-lock.json
@@ -4,6 +4,7 @@
 	"requires": true,
 	"packages": {
 		"": {
+			"name": "shared",
 			"devDependencies": {
 				"@types/jest": "30.0.0",
 				"jest": "30.3.0",
@@ -38,7 +39,6 @@
 			"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.0.tgz",
 			"integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
 			"dev": true,
-			"peer": true,
 			"dependencies": {
 				"@babel/code-frame": "^7.29.0",
 				"@babel/generator": "^7.29.0",
@@ -1397,9 +1397,9 @@
 			}
 		},
 		"node_modules/anymatch/node_modules/picomatch": {
-			"version": "2.3.1",
-			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-			"integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+			"version": "2.3.2",
+			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+			"integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
 			"dev": true,
 			"engines": {
 				"node": ">=8.6"
@@ -1527,9 +1527,9 @@
 			}
 		},
 		"node_modules/brace-expansion": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-			"integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.3.tgz",
+			"integrity": "sha512-MCV/fYJEbqx68aE58kv2cA/kiky1G8vux3OR6/jbS+jIMe/6fJWa0DTzJU7dqijOWYwHi1t29FlfYI9uytqlpA==",
 			"dev": true,
 			"dependencies": {
 				"balanced-match": "^1.0.0"
@@ -1554,7 +1554,6 @@
 					"url": "https://github.com/sponsors/ai"
 				}
 			],
-			"peer": true,
 			"dependencies": {
 				"baseline-browser-mapping": "^2.9.0",
 				"caniuse-lite": "^1.0.30001759",
@@ -2117,9 +2116,9 @@
 			"dev": true
 		},
 		"node_modules/handlebars": {
-			"version": "4.7.8",
-			"resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.8.tgz",
-			"integrity": "sha512-vafaFqs8MZkRrSX7sFVUdo3ap/eNiLnb4IakshzvP56X5Nr1iGKAIqdX6tMlm6HcNRIkr6AxO5jFEoJzzpT8aQ==",
+			"version": "4.7.9",
+			"resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.9.tgz",
+			"integrity": "sha512-4E71E0rpOaQuJR2A3xDZ+GM1HyWYv1clR58tC8emQNeQe3RH7MAzSbat+V0wG78LQBo6m6bzSG/L4pBuCsgnUQ==",
 			"dev": true,
 			"dependencies": {
 				"minimist": "^1.2.5",
@@ -2346,7 +2345,6 @@
 			"resolved": "https://registry.npmjs.org/jest/-/jest-30.3.0.tgz",
 			"integrity": "sha512-AkXIIFcaazymvey2i/+F94XRnM6TsVLZDhBMLsd1Sf/W0wzsvvpjeyUrCZD6HGG4SDYPgDJDBKeiJTBb10WzMg==",
 			"dev": true,
-			"peer": true,
 			"dependencies": {
 				"@jest/core": "30.3.0",
 				"@jest/types": "30.3.0",
@@ -3308,9 +3306,9 @@
 			"dev": true
 		},
 		"node_modules/picomatch": {
-			"version": "4.0.3",
-			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-			"integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+			"version": "4.0.4",
+			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+			"integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
 			"dev": true,
 			"engines": {
 				"node": ">=12"
@@ -3708,9 +3706,9 @@
 			}
 		},
 		"node_modules/test-exclude/node_modules/brace-expansion": {
-			"version": "1.1.12",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-			"integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+			"version": "1.1.13",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
+			"integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
 			"dev": true,
 			"dependencies": {
 				"balanced-match": "^1.0.0",


### PR DESCRIPTION
There were a few minor, major, and critical vulnerabilities in dependencies. I figured adding the commands would make it easier for us to check our dependencies and update in future.

We could also allow GitHub's Dependabot to handle that stuff for us, if we decide we want less responsibility/control over this stuff.