### PR TITLE
Add script to clone wiki and add wiki/ to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ dist
 .coverage
 .env
 *.swp
+wiki/

--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
 		"auditFix": "npm audit fix && cd shared && npm audit fix && cd ../backend && npm audit fix && cd ../frontend && npm audit fix && cd ../testing && npm audit fix",
 		"prettier": "npx prettier --write .",
 		"eslint": "npx eslint .",
-		"githook": "chmod +x scripts/pre-push-hook && cp scripts/pre-push-hook .git/hooks/pre-push"
+		"githook": "chmod +x scripts/pre-push-hook && cp scripts/pre-push-hook .git/hooks/pre-push",
+		"cloneWiki": "git clone \"$(git remote get-url origin | sed 's/\\.git$//')\".wiki.git wiki"
 	},
 	"type": "module",
 	"private": true,


### PR DESCRIPTION
Adds a `cloneWiki` script to the root `package.json` that clones the repo's wiki into `./wiki/`. The URL is derived from the git remote, so it'll work after a fork too. Also adds `wiki/` to `.gitignore`.