### PR TITLE
Create toasts functionality

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -19,7 +19,8 @@
 				"react-dom": "^19.2.0",
 				"react-router": "^7.13.1",
 				"socket.io-client": "^4.8.3",
-				"tailwindcss": "^4.2.2"
+				"tailwindcss": "^4.2.2",
+				"zustand": "^5.0.12"
 			},
 			"devDependencies": {
 				"@eslint/js": "^9.39.1",
@@ -2148,7 +2149,7 @@
 			"version": "19.2.14",
 			"resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
 			"integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
-			"dev": true,
+			"devOptional": true,
 			"dependencies": {
 				"csstype": "^3.2.2"
 			}
@@ -2713,7 +2714,7 @@
 			"version": "3.2.3",
 			"resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
 			"integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
-			"dev": true
+			"devOptional": true
 		},
 		"node_modules/debug": {
 			"version": "4.4.3",
@@ -4317,6 +4318,34 @@
 			},
 			"peerDependencies": {
 				"zod": "^3.25.0 || ^4.0.0"
+			}
+		},
+		"node_modules/zustand": {
+			"version": "5.0.12",
+			"resolved": "https://registry.npmjs.org/zustand/-/zustand-5.0.12.tgz",
+			"integrity": "sha512-i77ae3aZq4dhMlRhJVCYgMLKuSiZAaUPAct2AksxQ+gOtimhGMdXljRT21P5BNpeT4kXlLIckvkPM029OljD7g==",
+			"engines": {
+				"node": ">=12.20.0"
+			},
+			"peerDependencies": {
+				"@types/react": ">=18.0.0",
+				"immer": ">=9.0.6",
+				"react": ">=18.0.0",
+				"use-sync-external-store": ">=1.2.0"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				},
+				"immer": {
+					"optional": true
+				},
+				"react": {
+					"optional": true
+				},
+				"use-sync-external-store": {
+					"optional": true
+				}
 			}
 		}
 	}

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -22,7 +22,8 @@
 		"react-dom": "^19.2.0",
 		"react-router": "^7.13.1",
 		"socket.io-client": "^4.8.3",
-		"tailwindcss": "^4.2.2"
+		"tailwindcss": "^4.2.2",
+		"zustand": "^5.0.12"
 	},
 	"devDependencies": {
 		"@eslint/js": "^9.39.1",

--- a/frontend/src/components/Toast.tsx
+++ b/frontend/src/components/Toast.tsx
@@ -1,0 +1,127 @@
+import {useCallback, useEffect, useRef} from "react";
+import {createPortal} from "react-dom";
+import {useToastStore} from "./toastStore.ts";
+
+const MIN_TOAST_MS = 4000;
+const MS_PER_CHAR = 50;
+
+function toastDuration(message: string): number {
+	return Math.max(MIN_TOAST_MS, message.length * MS_PER_CHAR);
+}
+// WCAG 1.4.1 (A) / 1.3.1 (A): variant conveyed by icon + sr-only text, not colour alone
+const ICONS = {error: "⊘", success: "✓", info: "ℹ"} as const;
+
+function ToastItem({toast}: {toast: {id: number; message: string; variant: "error" | "success" | "info"}}) {
+	const dismiss = useToastStore((s) => s.dismiss);
+	const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+	const remainingRef = useRef(toastDuration(toast.message));
+	const startTimeRef = useRef(0);
+
+	useEffect(() => {
+		startTimeRef.current = Date.now();
+		timerRef.current = setTimeout(() => dismiss(toast.variant, toast.id), remainingRef.current);
+		return () => {
+			if (timerRef.current) clearTimeout(timerRef.current);
+		};
+	}, [toast.variant, toast.id, dismiss]);
+
+	// WCAG 2.2.1 (A): suspend auto-dismiss while pointer is over the toast or focus is within it
+	const pauseTimer = useCallback(() => {
+		if (timerRef.current) clearTimeout(timerRef.current);
+		remainingRef.current = Math.max(0, remainingRef.current - (Date.now() - startTimeRef.current));
+	}, []);
+
+	const resumeTimer = useCallback(() => {
+		startTimeRef.current = Date.now();
+		timerRef.current = setTimeout(() => dismiss(toast.variant, toast.id), remainingRef.current);
+	}, [toast.variant, toast.id, dismiss]);
+
+	return (
+		<div
+			// WCAG 1.4.10 (AA): max-w-sm + w-full + wrap-break-words allows reflow at 320 CSS px (400% zoom)
+			className={`toast-${toast.variant} flex items-center gap-2 min-w-70 max-w-sm w-full rounded border px-4 py-3 shadow-lg`}
+			onMouseEnter={pauseTimer}
+			onMouseLeave={resumeTimer}
+			onFocus={pauseTimer}
+			onBlur={resumeTimer}
+		>
+			{/* WCAG 1.3.1 (A) / 4.1.2 (A): decorative icon hidden from AT */}
+			<span aria-hidden="true" className="shrink-0 text-base leading-none">
+				{ICONS[toast.variant]}
+			</span>
+			{/* WCAG 1.3.1 (A): variant announced as text so it isn't colour-only */}
+			<span className="sr-only">{toast.variant}: </span>
+			<p className="flex-1 text-sm leading-snug wrap-break-words">{toast.message}</p>
+			<button
+				type="button"
+				// WCAG 2.5.3 (AA) / 4.1.2 (A): accessible name on an icon-only button
+				aria-label="Dismiss notification"
+				// WCAG 2.1.1 (A): button is keyboard operable
+				onClick={() => dismiss(toast.variant, toast.id)}
+				// WCAG 2.4.7 (AA) / 1.4.11 (AA): visible focus ring with ≥3:1 contrast against background
+				className="shrink-0 rounded p-0.5 opacity-80 hover:opacity-100 focus-visible:outline-2 focus-visible:outline-offset-1 focus-visible:outline-white cursor-pointer"
+			>
+				<span aria-hidden="true" className="text-base leading-none">
+					✕
+				</span>
+			</button>
+		</div>
+	);
+}
+
+export function ToastContainer() {
+	const politeToasts = useToastStore((s) => s.politeToasts);
+	const assertiveToasts = useToastStore((s) => s.assertiveToasts);
+	const toasts = [...assertiveToasts, ...politeToasts];
+	const dismiss = useToastStore((s) => s.dismiss);
+
+	// WCAG 2.1.1 (A): Escape dismisses the most recent toast without requiring focus on it
+	useEffect(() => {
+		if (toasts.length === 0) return;
+		function handleKeyDown(e: KeyboardEvent) {
+			const latestToast = toasts[toasts.length - 1];
+			if (e.key === "Escape") dismiss(latestToast.variant, latestToast.id);
+		}
+		window.addEventListener("keydown", handleKeyDown);
+		return () => window.removeEventListener("keydown", handleKeyDown);
+	}, [toasts, dismiss]);
+
+	// Portals always render — the live regions must exist in the DOM before any toast appears so screen readers pre-register them.
+	// Never return null in here.
+	return createPortal(
+		<>
+			{/*
+			 * WCAG 4.1.3 (AA): persistent aria-live regions pre-registered in the DOM.
+			 * assertive for errors (interrupts), polite for success/info (waits for idle).
+			 * aria-atomic="false" announces only newly added children, not the full list.
+			 */}
+			<div aria-live="assertive" aria-atomic="false" className="sr-only">
+				{toasts
+					.filter((t) => t.variant === "error")
+					.map((t) => (
+						<span key={t.id}>
+							{t.variant}: {t.message}
+						</span>
+					))}
+			</div>
+			<div aria-live="polite" aria-atomic="false" className="sr-only">
+				{toasts
+					.filter((t) => t.variant !== "error")
+					.map((t) => (
+						<span key={t.id}>
+							{t.variant}: {t.message}
+						</span>
+					))}
+			</div>
+			{/* WCAG 4.1.2 (A): landmark label so AT users can navigate to notifications */}
+			{toasts.length > 0 && (
+				<div aria-label="Notifications" className="fixed bottom-4 left-4 z-50 flex flex-col gap-2 items-start">
+					{toasts.map((toast) => (
+						<ToastItem key={toast.id} toast={toast} />
+					))}
+				</div>
+			)}
+		</>,
+		document.body,
+	);
+}

--- a/frontend/src/components/toastStore.ts
+++ b/frontend/src/components/toastStore.ts
@@ -1,0 +1,39 @@
+import {create} from "zustand";
+
+export type ToastVariant = "error" | "success" | "info";
+
+type Toast = {
+	id: number;
+	message: string;
+	variant: ToastVariant;
+};
+
+type ToastStore = {
+	assertiveToasts: Toast[];
+	politeToasts: Toast[];
+	showToast: (variant: ToastVariant, message: string) => void;
+	dismiss: (variant: ToastVariant, id: number) => void;
+};
+
+let nextId = 0;
+
+export const useToastStore = create<ToastStore>((set) => ({
+	politeToasts: [],
+	assertiveToasts: [],
+	showToast: (variant: ToastVariant, message: string) => {
+		const id = nextId++;
+		if (variant == "error") set((state) => ({assertiveToasts: [...state.assertiveToasts, {id, message, variant}]}));
+		else set((state) => ({politeToasts: [...state.politeToasts, {id, message, variant}]}));
+	},
+	dismiss: (variant: ToastVariant, id: number) => {
+		if (variant === "error") {
+			set((state) => ({
+				assertiveToasts: state.assertiveToasts.filter((t) => t.id !== id),
+			}));
+		} else {
+			set((state) => ({
+				politeToasts: state.politeToasts.filter((t) => t.id !== id),
+			}));
+		}
+	},
+}));

--- a/frontend/src/components/toastStore.ts
+++ b/frontend/src/components/toastStore.ts
@@ -22,7 +22,7 @@ export const useToastStore = create<ToastStore>((set) => ({
 	assertiveToasts: [],
 	showToast: (variant: ToastVariant, message: string) => {
 		const id = nextId++;
-		if (variant == "error") set((state) => ({assertiveToasts: [...state.assertiveToasts, {id, message, variant}]}));
+		if (variant === "error") set((state) => ({assertiveToasts: [...state.assertiveToasts, {id, message, variant}]}));
 		else set((state) => ({politeToasts: [...state.politeToasts, {id, message, variant}]}));
 	},
 	dismiss: (variant: ToastVariant, id: number) => {

--- a/frontend/src/dashboard/FileUpload.tsx
+++ b/frontend/src/dashboard/FileUpload.tsx
@@ -1,17 +1,19 @@
 import {useState, useRef} from "react";
 import {Button} from "../components/Button";
+import {useToastStore} from "../components/toastStore.ts";
 
 function FileUploader({refreshFileList}: {refreshFileList: () => void}) {
 	const [fileUploads, setFileUploads] = useState<FileList | null>(null);
 	const fileInputRef = useRef<HTMLInputElement>(null);
 	const MAX_FILE_SIZE = 1000000; // 1meg
+	const showToast = useToastStore((s) => s.showToast);
 
 	function handleFileChange(e: React.ChangeEvent<HTMLInputElement>) {
 		if (!e.target.files) return;
 
 		for (const f of e.target.files) {
 			if (f.size > MAX_FILE_SIZE) {
-				window.alert(`File '${f.name}' too large at ${f.size} (max. ${MAX_FILE_SIZE})`);
+				showToast("error", `File '${f.name}' too large at ${f.size} (max. ${MAX_FILE_SIZE})`);
 				console.error(`File '${f.name}' too large at ${f.size} (max. ${MAX_FILE_SIZE})`);
 				setFileUploads(null);
 				return;
@@ -39,7 +41,7 @@ function FileUploader({refreshFileList}: {refreshFileList: () => void}) {
 				if (result.status === 409) {
 					const res = await result.json();
 					console.error(`${res.error.detail}`);
-					window.alert(`${res.error.detail}`);
+					showToast("error", `${res.error.detail}`);
 					setFileUploads(null);
 					return;
 				}

--- a/frontend/src/dashboard/NewFile.tsx
+++ b/frontend/src/dashboard/NewFile.tsx
@@ -1,11 +1,13 @@
 import {useState} from "react";
 import {useNavigate} from "react-router";
 import {Button} from "../components/Button";
+import {useToastStore} from "../components/toastStore.ts";
 
 function NewFile() {
 	const [newFilename, setNewFilename] = useState<string>();
 	const [showFilenamePrompt, setShowFilenamePrompt] = useState(false);
 	const navigate = useNavigate();
+	const showToast = useToastStore((s) => s.showToast);
 
 	async function openNewFile() {
 		try {
@@ -19,7 +21,7 @@ function NewFile() {
 
 			if (result.status === 409) {
 				console.error(`${res.error}`);
-				window.alert(`${res.error}`);
+				showToast("error", `${res.error}`);
 				return;
 			} else if (!result.ok) {
 				console.error("File creation failed!");

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -9,6 +9,18 @@
 	--font-family-sans: Arial, sans-serif;
 }
 
+@layer toasts {
+	.toast-error {
+		@apply bg-red-700 border-red-500 text-white;
+	}
+	.toast-success {
+		@apply bg-green-700 border-green-500 text-white;
+	}
+	.toast-info {
+		@apply bg-surface border-accent text-white;
+	}
+}
+
 @layer base {
 	:root {
 		background-color: var(--color-canvas);

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -9,9 +9,11 @@ import EditorPage from "./codeEditor/Editor.page.tsx";
 import FileBrowserPage from "./dashboard/FileBrowser.page.tsx";
 import Dashboard from "./user/dashboard.page.tsx";
 import UserLayout from "./user/layout/UserLayout.tsx";
+import {ToastContainer} from "./components/Toast.tsx";
 
 createRoot(document.getElementById("root")!).render(
 	<StrictMode>
+		<ToastContainer />
 		<BrowserRouter>
 			<Routes>
 				<Route path="/" element={<App />} />

--- a/frontend/src/user/layout/TopBar.tsx
+++ b/frontend/src/user/layout/TopBar.tsx
@@ -1,9 +1,11 @@
 import {Link, useNavigate} from "react-router";
 import {Button} from "../../components/Button";
+import {useToastStore} from "../../components/toastStore.ts";
 import type {MouseEvent} from "react";
 
 export default function TopBar() {
 	const navigate = useNavigate();
+	const showToast = useToastStore((s) => s.showToast);
 
 	async function logout(event: MouseEvent<HTMLButtonElement>) {
 		event.preventDefault();
@@ -16,11 +18,11 @@ export default function TopBar() {
 				navigate("/login");
 			} else {
 				const data = await response.json();
-				window.alert(data.error || "Logout failed");
+				showToast("error", data.error || "Logout failed");
 			}
 		} catch (e) {
 			console.error("Logout error:", e);
-			window.alert("Network error. Please try again.");
+			showToast("error", "Network error. Please try again.");
 		}
 	}
 

--- a/frontend/src/user/login.page.tsx
+++ b/frontend/src/user/login.page.tsx
@@ -2,11 +2,13 @@ import {useState, useEffect} from "react";
 import type {SubmitEvent} from "react";
 import {useNavigate} from "react-router";
 import {getSession} from "../utils.ts";
+import {useToastStore} from "../components/toastStore.ts";
 
 export default function LoginPage() {
 	const [loginIdentifier, setLoginIdentifier] = useState("");
 	const [loginPassword, setLoginPassword] = useState("");
 	const navigate = useNavigate();
+	const showToast = useToastStore((s) => s.showToast);
 
 	useEffect(() => {
 		getSession().then((isLoggedIn) => {
@@ -38,8 +40,7 @@ export default function LoginPage() {
 			console.log("login successful");
 			navigate("/dashboard");
 		} catch (e) {
-			// TODO! Add the toast
-			window.alert(`Login failed. ${e}`);
+			showToast("error", `Login failed. ${e instanceof Error ? e.message : String(e)}`);
 		}
 	};
 

--- a/frontend/src/user/signup.page.tsx
+++ b/frontend/src/user/signup.page.tsx
@@ -4,6 +4,7 @@ import type {SubmitEvent} from "react";
 import type {SigningUser} from "#shared/src/types";
 import {getSession} from "../utils.ts";
 import {z} from "zod";
+import {useToastStore} from "../components/toastStore.ts";
 
 const emailSchema = z.email();
 
@@ -13,6 +14,7 @@ export default function SignupPage() {
 	const [password, setUserPassword] = useState("");
 	const [password2, setUserPassword2] = useState("");
 	const navigate = useNavigate();
+	const showToast = useToastStore((s) => s.showToast);
 
 	useEffect(() => {
 		getSession().then((isLoggedIn) => {
@@ -59,8 +61,7 @@ export default function SignupPage() {
 			console.log("Signup successful");
 			navigate("/login");
 		} catch (e) {
-			// TODO! Add the toast
-			window.alert(e);
+			showToast("error", e instanceof Error ? e.message : String(e));
 		}
 	};
 


### PR DESCRIPTION
- Added Zustand as a dependency for frontend global state-management, which is used for toasts in this commit but in future could also be used for user state. We decided against the React built-in solution (Providers) since they'd reload more components unnecessarily.
- I heavily documented the WCAG compliance because there's some know-how to making toasts accessible (especially to the WCAG 2.1 AA standards from the subject's module).
- This replaces all the `window.alert` calls, but does not replace `window.confirm`. Making a `confirm` accessible toast alternative is a bit less trivial, so we can decide in future if that's really necessary.

Closes #72 