### PR TITLE
FilePicker-adjacent UX improvements

### DIFF
--- a/backend/src/endpoints/collabSocket.ts
+++ b/backend/src/endpoints/collabSocket.ts
@@ -360,12 +360,6 @@ export function initCollabSocket(sockets: Server, db: Pool): CollabSocketApi {
 
 				switch (type) {
 					case "pickFile": {
-						if (workspace.memberFiles.has(userId)) {
-							sendResponse({
-								error: "You have already picked a file for this session",
-							} satisfies ErrorResponse);
-							break;
-						}
 						if (!data.fileId || typeof data.fileId !== "string") {
 							sendResponse({error: "Invalid file ID"} satisfies ErrorResponse);
 							break;
@@ -374,6 +368,16 @@ export function initCollabSocket(sockets: Server, db: Pool): CollabSocketApi {
 						if (!doc) {
 							sendResponse({error: "File not found or not owned by you"} satisfies ErrorResponse);
 							break;
+						}
+						const oldFileId = workspace.memberFiles.get(userId);
+						if (oldFileId) {
+							workspace.memberFiles.delete(userId);
+							try {
+								await broadcastMembers(workspace);
+							} catch (err) {
+								timestampedLog(`Failed to broadcast members after pickFile: ${String(err)}`);
+							}
+							await releaseDocRef(oldFileId);
 						}
 						workspace.memberFiles.set(userId, data.fileId);
 						sendResponse(true);

--- a/backend/src/endpoints/collabSocket.ts
+++ b/backend/src/endpoints/collabSocket.ts
@@ -17,9 +17,9 @@ import type {
 	WorkspaceInfo,
 } from "#shared/src/types.js";
 
-const DATABASE_SAVE_DEBOUNCE_TIME = 1500;
-// Gives users time to refresh, recover from a network blip, or navigate back before collab state is flushed
-const WORKSPACE_DESTROY_GRACE_MS = 10_000;
+const DATABASE_SAVE_DEBOUNCE_MS = 1500;
+// Gives users time to refresh, recover from a network blip, or navigate back before participation/workspace is destroyed & flushed
+const DISCONNECT_GRACE_MS = 10_000;
 
 type LiveDocState = {
 	ownerId: number;
@@ -41,6 +41,7 @@ type Workspace = {
 	memberFiles: Map<number, string>;
 	connectedSockets: Map<string, number>;
 	destroyTimer: ReturnType<typeof setTimeout> | null;
+	memberDisconnectTimers: Map<number, ReturnType<typeof setTimeout>>;
 };
 
 type CollabSocketState = {
@@ -201,7 +202,7 @@ export function initCollabSocket(sockets: Server, db: Pool): CollabSocketApi {
 		if (doc.dbSaveDebounceTimer) {
 			clearTimeout(doc.dbSaveDebounceTimer);
 		}
-		doc.dbSaveDebounceTimer = setTimeout(() => void flushDoc(doc), DATABASE_SAVE_DEBOUNCE_TIME);
+		doc.dbSaveDebounceTimer = setTimeout(() => flushDoc(doc), DATABASE_SAVE_DEBOUNCE_MS);
 	}
 
 	async function releaseDocRef(fileId: string): Promise<void> {
@@ -223,9 +224,32 @@ export function initCollabSocket(sockets: Server, db: Pool): CollabSocketApi {
 	}
 
 	async function destroyWorkspace(workspace: Workspace): Promise<void> {
+		for (const timer of workspace.memberDisconnectTimers.values()) {
+			clearTimeout(timer);
+		}
+		workspace.memberDisconnectTimers.clear();
 		state.workspaces.delete(workspace.workspaceId);
 		for (const fileId of workspace.memberFiles.values()) {
 			await releaseDocRef(fileId);
+		}
+	}
+
+	function scheduleMemberRemoval(workspace: Workspace, userId: number): void {
+		if (workspace.memberDisconnectTimers.has(userId)) return;
+		workspace.memberDisconnectTimers.set(
+			userId,
+			setTimeout(() => {
+				workspace.memberDisconnectTimers.delete(userId);
+				void removeUserFromWorkspace(workspace, userId);
+			}, DISCONNECT_GRACE_MS),
+		);
+	}
+
+	function cancelMemberRemoval(workspace: Workspace, userId: number): void {
+		const timer = workspace.memberDisconnectTimers.get(userId);
+		if (timer !== undefined) {
+			clearTimeout(timer);
+			workspace.memberDisconnectTimers.delete(userId);
 		}
 	}
 
@@ -236,13 +260,14 @@ export function initCollabSocket(sockets: Server, db: Pool): CollabSocketApi {
 			// Someone reconnected during the grace window — skip destruction.
 			if (workspace.connectedSockets.size > 0) return;
 			void destroyWorkspace(workspace);
-		}, WORKSPACE_DESTROY_GRACE_MS);
+		}, DISCONNECT_GRACE_MS);
 	}
 
 	function attachSocketToWorkspace(socket: Socket, workspace: Workspace, userId: number): void {
 		if (workspace.connectedSockets.has(socket.id)) return;
 		workspace.connectedSockets.set(socket.id, userId);
 		socket.join(buildWorkspaceName(workspace.workspaceId));
+		cancelMemberRemoval(workspace, userId);
 	}
 
 	function detachSocketFromWorkspace(socketId: string, workspace: Workspace): void {
@@ -280,6 +305,7 @@ export function initCollabSocket(sockets: Server, db: Pool): CollabSocketApi {
 			memberFiles: new Map([[userId, fileId]]),
 			connectedSockets: new Map(),
 			destroyTimer: null,
+			memberDisconnectTimers: new Map(),
 		};
 		// Give the creator time to navigate and open a socket before we'd auto-clean.
 		scheduleWorkspaceDestroy(workspace);
@@ -303,9 +329,7 @@ export function initCollabSocket(sockets: Server, db: Pool): CollabSocketApi {
 				detachSocketFromWorkspace(socket.id, workspace);
 				// Only evict if this user has no other sockets still connected to this workspace
 				const stillConnected = [...workspace.connectedSockets.values()].some((id) => id === userId);
-				if (!stillConnected) {
-					void removeUserFromWorkspace(workspace, userId);
-				}
+				if (!stillConnected) scheduleMemberRemoval(workspace, userId);
 				break;
 			}
 		});

--- a/frontend/src/codeEditor/Editor.page.tsx
+++ b/frontend/src/codeEditor/Editor.page.tsx
@@ -15,6 +15,7 @@ export default function EditorPage() {
 	const [sessionInfo, setSessionInfo] = useState<WorkspaceInfo | null>(null);
 	const [errorMessage, setErrorMessage] = useState<string | null>(null);
 	const [joining, setJoining] = useState(true);
+	const [showFilePicker, setShowFilePicker] = useState(false);
 
 	const connection = useMemo(() => (workspaceId ? new CollabConnection(workspaceId) : null), [workspaceId]);
 
@@ -43,6 +44,7 @@ export default function EditorPage() {
 		if (!connection) return;
 		const unsubscribe = connection.subscribeMembers((event) => {
 			setJoining(false);
+			setShowFilePicker(false);
 			setSessionInfo({
 				id: event.workspaceId,
 				members: event.members,
@@ -67,9 +69,16 @@ export default function EditorPage() {
 
 	const isMember = sessionInfo.members.some((member) => member.id === user.id);
 
-	if (!isMember) {
+	if (!isMember || showFilePicker) {
 		return <FilePicker connection={connection} />;
 	}
 
-	return <Editor connection={connection} myOwnerId={user.id} initialMembers={sessionInfo.members} />;
+	return (
+		<Editor
+			connection={connection}
+			myOwnerId={user.id}
+			initialMembers={sessionInfo.members}
+			onRepickFile={() => setShowFilePicker(true)}
+		/>
+	);
 }

--- a/frontend/src/codeEditor/Editor.tsx
+++ b/frontend/src/codeEditor/Editor.tsx
@@ -32,9 +32,10 @@ type SharedEditorProps = {
 	connection: CollabConnection;
 	myOwnerId: number;
 	initialMembers: WorkspaceMember[];
+	onRepickFile: () => void;
 };
 
-export default function Editor({connection, myOwnerId, initialMembers}: SharedEditorProps): JSX.Element {
+export default function Editor({connection, myOwnerId, initialMembers, onRepickFile}: SharedEditorProps): JSX.Element {
 	const showToast = useShowToast();
 	const [selectedPeerId, setSelectedPeerId] = useState<number | null>(null);
 	const [readyPeerIds, setReadyPeerIds] = useState<ReadonlySet<number>>(new Set());
@@ -206,18 +207,23 @@ export default function Editor({connection, myOwnerId, initialMembers}: SharedEd
 				selectedPeerId={selectedPeerId}
 				onSelect={setSelectedPeerId}
 			/>
-			<form
-				className="flex gap-2 p-1"
-				onSubmit={(e) => {
-					e.preventDefault();
-					void handleRename();
-				}}
-			>
-				<Input type="text" value={fileName} onChange={(e) => setFileName(e.target.value)} />
-				<Button type="submit" className="border px-2">
-					Rename
+			<div className="flex items-center justify-between p-1">
+				<form
+					className="flex gap-2"
+					onSubmit={(e) => {
+						e.preventDefault();
+						void handleRename();
+					}}
+				>
+					<Input type="text" value={fileName} onChange={(e) => setFileName(e.target.value)} />
+					<Button type="submit" className="border px-2">
+						Rename
+					</Button>
+				</form>
+				<Button type="button" className="border px-2" onClick={onRepickFile}>
+					Change file
 				</Button>
-			</form>
+			</div>
 			{error ? (
 				<div className="border border-error-accent p-2 text-error-accent">
 					<div>Error initializing editor: {error}</div>


### PR DESCRIPTION
- Fixed file-picker showing on momentary disconnect (e.g. page refresh)
  - I did this by expanding the workspace-destroy grace period to affect member disconnects.
- Introduced button in editor page to send oneself back to the file picker.
  - This works by, when a new file is selected, rapidly disconnecting member with the previous file and reconnecting it with a new file. This quick reconnect is not very noticeable for the repicker, but potentially a bit jarring for the collaborators. This is maybe a bit hacky and could be replaced with a more seamless file-swap, but this soluition is more reviewable/straight-forward and probably fine considering our time budget.