### PR TITLE
102 fb separate file upload into multiple calls

### DIFF
--- a/backend/src/endpoints/files.ts
+++ b/backend/src/endpoints/files.ts
@@ -11,6 +11,7 @@ import multer from "multer";
 // doing #shared does not work for some reason
 // having is text or binary package only in shard is not enought for some reason, also need in backend
 import {validateFile} from "../../../shared/src/fileValidation.js";
+import assert from "node:assert";
 
 // doing #shared does not work for some reason
 
@@ -94,7 +95,7 @@ function uploadFile(app: Express, db: Pool) {
 				return res.status(415).json({ok: false, error: err});
 			}
 
-			const query = `INSERT INTO files (id, name, content, owner_id) VALUES ($1, $2, $3, $4) RETURNING id;`;
+			const query = "INSERT INTO files (id, name, content, owner_id) VALUES ($1, $2, $3, $4) RETURNING id";
 			const values = [crypto.randomUUID(), f.originalname, fileText, req.session.userId];
 
 			timestampedLog(`DB QUERY >>> ${query}`);
@@ -102,11 +103,10 @@ function uploadFile(app: Express, db: Pool) {
 
 			try {
 				const result = await db.query(query, values);
-				if (result.rowCount !== 1) {
-					// placeholder
-					return res.status(500).json({ok: false, error: "Internal server error"});
-				}
-				const fileId = result.rows[0];
+				assert(result.rowCount === 1, "Result did not contain any rows");
+				const fileId = result.rows[0].id;
+				assert(fileId, "Result did not contain an id field");
+
 				return res.status(201).json({ok: true, data: fileId});
 			} catch (error: unknown) {
 				if (!isDbError(error)) {

--- a/backend/src/endpoints/files.ts
+++ b/backend/src/endpoints/files.ts
@@ -13,8 +13,6 @@ import multer from "multer";
 import {validateFile} from "../../../shared/src/fileValidation.js";
 import assert from "node:assert";
 
-// doing #shared does not work for some reason
-
 function getFiles(app: Express, db: Pool) {
 	app.get("/api/files", requireAuth, async (req: Request, res: Response<ApiResponse<UserFile[]>>) => {
 		timestampedLog(`REQUEST >>> ${req.method} ${req.url}`);

--- a/backend/src/endpoints/files.ts
+++ b/backend/src/endpoints/files.ts
@@ -9,7 +9,6 @@ import {isDbError, isInvalidByteSequence, isUniqueViolation} from "#/src/utils.j
 import multer from "multer";
 
 // doing #shared does not work for some reason
-// having is text or binary package only in shard is not enought for some reason, also need in backend
 import {validateFile} from "../../../shared/src/fileValidation.js";
 import assert from "node:assert";
 
@@ -68,7 +67,6 @@ function getFileById(app: Express, db: Pool) {
 	});
 }
 
-// const storage = multer.memoryStorage();
 const upload = multer({
 	storage: multer.memoryStorage(),
 });

--- a/backend/src/endpoints/files.ts
+++ b/backend/src/endpoints/files.ts
@@ -74,46 +74,40 @@ const upload = multer({
 	storage: multer.memoryStorage(),
 });
 
-function uploadFiles(app: Express, db: Pool) {
+function uploadFile(app: Express, db: Pool) {
 	app.post(
 		"/api/files",
 		requireAuth,
-		upload.array("file", 100),
-		async (req: Request, res: Response<ApiResponse<string[]>>) => {
+		upload.single("file"),
+		async (req: Request, res: Response<ApiResponse<string>>) => {
 			timestampedLog(`REQUEST >>> ${req.method} ${req.url}`);
 
-			if (!Array.isArray(req.files) || !req.files.length) {
+			if (!req.file) {
 				return res.status(400).json({ok: false, error: "No files provided"});
 			}
 
-			const fileErrors: string[] = [];
-			for (const f of req.files) {
-				const err: string | null = validateFile(f.mimetype, f.size, f.buffer.toString("utf8"), f.originalname);
-				if (err) fileErrors.push(`File '${f.originalname}': ${err}`);
+			const f = req.file;
+			const fileText = f.buffer.toString("utf8");
+
+			const err: string | null = validateFile(f.mimetype, f.size, fileText, f.originalname);
+			if (err) {
+				return res.status(415).json({ok: false, error: err});
 			}
-			if (fileErrors.length > 0) {
-				return res.status(415).json({ok: false, error: fileErrors.join("\0")});
-			}
 
-			// build the parameterized sql query
-			const rows = req.files.map((_, i) => {
-				const offset = 4 * i;
-				return `($${offset + 1}, $${offset + 2}, $${offset + 3}, $${offset + 4})`;
-			});
-
-			const query = `INSERT INTO files (id, name, content, owner_id) VALUES ${rows.join(", ")} RETURNING id;`;
-
-			const values = req.files.flatMap((file) => {
-				return [crypto.randomUUID(), file.originalname, file.buffer.toString("utf8"), req.session.userId];
-			});
+			const query = `INSERT INTO files (id, name, content, owner_id) VALUES ($1, $2, $3, $4) RETURNING id;`;
+			const values = [crypto.randomUUID(), f.originalname, fileText, req.session.userId];
 
 			timestampedLog(`DB QUERY >>> ${query}`);
 			timestampedLog(`DB VALUES >>> ${JSON.stringify(values)}`);
 
 			try {
 				const result = await db.query(query, values);
-				const ids = result.rows.map((row) => row.id);
-				return res.status(201).json({ok: true, data: ids});
+				if (result.rowCount !== 1) {
+					// placeholder
+					return res.status(500).json({ok: false, error: "Internal server error"});
+				}
+				const fileId = result.rows[0];
+				return res.status(201).json({ok: true, data: fileId});
 			} catch (error: unknown) {
 				if (!isDbError(error)) {
 					timestampedLog(`ERROR <<< ${error}`);
@@ -124,18 +118,10 @@ function uploadFiles(app: Express, db: Pool) {
 				// this binary file handling happens if the checks before db fail
 				// @NOTE the messaging is different from normal checks
 				if (isInvalidByteSequence(error)) {
-					const msg =
-						req.files.length === 1
-							? `File '${req.files[0].originalname}' has binary encoding`
-							: "One or more files have binary encoding";
-					return res.status(415).json({ok: false, error: msg});
+					return res.status(415).json({ok: false, error: `File '${f.originalname}' has binary encoding`});
 				}
 				if (isUniqueViolation(error)) {
-					const msg =
-						req.files.length === 1
-							? `A file with name '${req.files[0].originalname}' already exists`
-							: "One or more of the filenames already exist";
-					return res.status(409).json({ok: false, error: msg});
+					return res.status(409).json({ok: false, error: `A file with name '${f.originalname}' already exists`});
 				}
 
 				return res.status(500).json({ok: false, error: "Internal server error"});
@@ -177,4 +163,4 @@ function deleteFile(app: Express, db: Pool) {
 	});
 }
 
-export default {getFiles, getFileById, uploadFiles, deleteFile};
+export default {getFiles, getFileById, uploadFile, deleteFile};

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -31,7 +31,7 @@ app.use(helmetSecurity());
 
 Endpoints.getFiles(app, postgres);
 Endpoints.getFileById(app, postgres);
-Endpoints.uploadFiles(app, postgres);
+Endpoints.uploadFile(app, postgres);
 Endpoints.deleteFile(app, postgres);
 
 UserEndpoints.signupUser(app);

--- a/frontend/src/codeEditor/FilePicker.tsx
+++ b/frontend/src/codeEditor/FilePicker.tsx
@@ -1,25 +1,21 @@
 import {type JSX} from "react";
 import {CollabConnection, pickFile} from "./collabClient";
 import FileBrowser from "../fileBrowser/FileBrowser";
-import {useShowToast} from "../stores/toastStore";
-import useFileBrowser from "../fileBrowser/useFileBrowser";
 
 type FilePickerProps = {
 	connection: CollabConnection;
 };
 
 function FilePicker({connection}: FilePickerProps): JSX.Element {
-	const showtoast = useShowToast();
-	const {refreshFileList} = useFileBrowser();
-
 	async function handlePick(fileId: string) {
 		try {
 			await pickFile(connection, fileId);
 		} catch (err) {
-			const error: Error = err as Error;
-			console.log(error.message);
-			showtoast("error", error.message);
-			refreshFileList();
+			if (err && typeof err === "object" && "message" in err) {
+				if (typeof err.message === "string") throw err.message;
+			} else {
+				throw "socker error";
+			}
 		}
 	}
 

--- a/frontend/src/codeEditor/FilePicker.tsx
+++ b/frontend/src/codeEditor/FilePicker.tsx
@@ -1,14 +1,26 @@
 import {type JSX} from "react";
 import {CollabConnection, pickFile} from "./collabClient";
 import FileBrowser from "../fileBrowser/FileBrowser";
+import {useShowToast} from "../stores/toastStore";
+import useFileBrowser from "../fileBrowser/useFileBrowser";
 
 type FilePickerProps = {
 	connection: CollabConnection;
 };
 
 function FilePicker({connection}: FilePickerProps): JSX.Element {
+	const showtoast = useShowToast();
+	const {refreshFileList} = useFileBrowser();
+
 	async function handlePick(fileId: string) {
-		await pickFile(connection, fileId);
+		try {
+			await pickFile(connection, fileId);
+		} catch (err) {
+			const error: Error = err as Error;
+			console.log(error.message);
+			showtoast("error", error.message);
+			refreshFileList();
+		}
 	}
 
 	return (

--- a/frontend/src/components/Button.tsx
+++ b/frontend/src/components/Button.tsx
@@ -12,7 +12,7 @@ const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(({children, clas
 	}
 
 	return (
-		<button ref={ref} className={`${getStyle()} m-1 p-1 ${className ?? ""}`} {...props}>
+		<button ref={ref} className={`${getStyle()} m-1 p-1 ${className ?? ""}`} disabled={disabled} {...props}>
 			{children}
 		</button>
 	);

--- a/frontend/src/fileBrowser/FileBrowser.page.tsx
+++ b/frontend/src/fileBrowser/FileBrowser.page.tsx
@@ -4,7 +4,6 @@ import {apiFetch} from "#/src/utils.ts";
 
 function FileBrowserPage() {
 	const navigate = useNavigate();
-	// const showToast = useShowToast();
 
 	async function startSessionFromFile(fileId: string) {
 		const response = await apiFetch<{workspaceId: string}>("/api/workspace", {

--- a/frontend/src/fileBrowser/FileBrowser.page.tsx
+++ b/frontend/src/fileBrowser/FileBrowser.page.tsx
@@ -1,22 +1,19 @@
 import FileBrowser from "./FileBrowser";
 import {useNavigate} from "react-router";
 import {apiFetch} from "#/src/utils.ts";
-import {useShowToast} from "#/src/stores/toastStore";
 
 function FileBrowserPage() {
 	const navigate = useNavigate();
-	const showToast = useShowToast();
+	// const showToast = useShowToast();
 
-	async function startSessionFromFile(fileId: string, refreshFileList?: () => void) {
+	async function startSessionFromFile(fileId: string) {
 		const response = await apiFetch<{workspaceId: string}>("/api/workspace", {
 			method: "POST",
 			headers: {"Content-Type": "application/json"},
 			body: JSON.stringify({fileId: fileId}),
 		});
 		if (!response.ok) {
-			showToast("error", response.error);
-			refreshFileList?.();
-			return;
+			throw response.error;
 		}
 		navigate(`/collab/${response.data.workspaceId}`);
 	}

--- a/frontend/src/fileBrowser/FileBrowser.page.tsx
+++ b/frontend/src/fileBrowser/FileBrowser.page.tsx
@@ -7,7 +7,7 @@ function FileBrowserPage() {
 	const navigate = useNavigate();
 	const showToast = useShowToast();
 
-	async function startSessionFromFile(fileId: string) {
+	async function startSessionFromFile(fileId: string, refreshFileList?: () => void) {
 		const response = await apiFetch<{workspaceId: string}>("/api/workspace", {
 			method: "POST",
 			headers: {"Content-Type": "application/json"},
@@ -15,6 +15,7 @@ function FileBrowserPage() {
 		});
 		if (!response.ok) {
 			showToast("error", response.error);
+			refreshFileList?.();
 			return;
 		}
 		navigate(`/collab/${response.data.workspaceId}`);

--- a/frontend/src/fileBrowser/FileBrowser.tsx
+++ b/frontend/src/fileBrowser/FileBrowser.tsx
@@ -40,7 +40,7 @@ function FileBrowser({onFileSelect}: fileBrowserProps) {
 				descending={sortDescending}
 			/>
 			{totalPages ? <PageSelector currentPage={page} totalPages={totalPages} onPageChange={setPage} /> : null}
-			<NewFile onFileCreate={onFileSelect} />
+			<NewFile onFileCreate={onFileSelect} refreshFileList={refreshFileList} />
 			<FileUploader pushToFileList={pushToFileList} refreshFileList={refreshFileList} />
 		</div>
 	);

--- a/frontend/src/fileBrowser/FileBrowser.tsx
+++ b/frontend/src/fileBrowser/FileBrowser.tsx
@@ -1,7 +1,7 @@
 import FileList from "./FileList";
 import PageSelector from "./PageSelector";
 import NewFile from "./NewFile";
-import FileUploader from "./FileUpload";
+import FileUploader from "./FileUploader";
 import useFileBrowser from "./useFileBrowser";
 import Input from "#/src/components/Input";
 

--- a/frontend/src/fileBrowser/FileBrowser.tsx
+++ b/frontend/src/fileBrowser/FileBrowser.tsx
@@ -20,6 +20,7 @@ function FileBrowser({onFileSelect}: fileBrowserProps) {
 		sortDescending,
 		toggleSort,
 		refreshFileList,
+		pushToFileList,
 		totalFiles,
 	} = useFileBrowser();
 
@@ -40,7 +41,7 @@ function FileBrowser({onFileSelect}: fileBrowserProps) {
 			/>
 			{totalPages ? <PageSelector currentPage={page} totalPages={totalPages} onPageChange={setPage} /> : null}
 			<NewFile onFileCreate={onFileSelect} />
-			<FileUploader refreshFileList={refreshFileList} />
+			<FileUploader pushToFileList={pushToFileList} />
 		</div>
 	);
 }

--- a/frontend/src/fileBrowser/FileBrowser.tsx
+++ b/frontend/src/fileBrowser/FileBrowser.tsx
@@ -6,7 +6,7 @@ import useFileBrowser from "./useFileBrowser";
 import Input from "#/src/components/Input";
 
 type fileBrowserProps = {
-	onFileSelect: (fileId: string) => void;
+	onFileSelect: (fileId: string) => Promise<void>;
 };
 
 function FileBrowser({onFileSelect}: fileBrowserProps) {
@@ -41,7 +41,7 @@ function FileBrowser({onFileSelect}: fileBrowserProps) {
 			/>
 			{totalPages ? <PageSelector currentPage={page} totalPages={totalPages} onPageChange={setPage} /> : null}
 			<NewFile onFileCreate={onFileSelect} />
-			<FileUploader pushToFileList={pushToFileList} />
+			<FileUploader pushToFileList={pushToFileList} refreshFileList={refreshFileList} />
 		</div>
 	);
 }

--- a/frontend/src/fileBrowser/FileList.tsx
+++ b/frontend/src/fileBrowser/FileList.tsx
@@ -1,4 +1,4 @@
-import type {UserFile} from "#shared/src/types";
+import type {FileListItem, UserFile} from "#shared/src/types";
 import type {JSX} from "react";
 import type {ApiResponse} from "#shared/src/types.js";
 import {apiFetch} from "#/src/utils.js";
@@ -7,7 +7,7 @@ import Button from "#/src/components/Button";
 
 type fileListProps = {
 	onFileSelect: (fileId: string) => void;
-	fileList: UserFile[];
+	fileList: FileListItem[];
 	refreshFileList: () => void;
 	onSortToggle: () => void;
 	descending: boolean;
@@ -18,12 +18,13 @@ function FileList({onFileSelect, fileList, refreshFileList, onSortToggle, descen
 
 	if (fileList.length === 0) return <p>No files to show.</p>;
 
-	async function handleDownload(file: UserFile) {
-		const response: ApiResponse<UserFile> = await apiFetch(`/api/files/${file.id}`);
+	async function handleDownload(file: FileListItem) {
+		const response: ApiResponse<Pick<UserFile, "content">> = await apiFetch(`/api/files/${file.id}`);
 
 		if (!response.ok) {
 			console.error(response.error);
 			showToast("error", `${response.error}`);
+			refreshFileList();
 			return;
 		}
 
@@ -55,7 +56,7 @@ function FileList({onFileSelect, fileList, refreshFileList, onSortToggle, descen
 		refreshFileList();
 	}
 
-	const listItems: JSX.Element[] = fileList.map<JSX.Element>((file: UserFile) => {
+	const listItems: JSX.Element[] = fileList.map<JSX.Element>((file: FileListItem) => {
 		return (
 			<tr key={file.id}>
 				<td>

--- a/frontend/src/fileBrowser/FileList.tsx
+++ b/frontend/src/fileBrowser/FileList.tsx
@@ -6,7 +6,7 @@ import {useShowToast} from "#/src/stores/toastStore";
 import Button from "#/src/components/Button";
 
 type fileListProps = {
-	onFileSelect: (fileId: string) => void;
+	onFileSelect: (fileId: string, refreshFileList: () => void) => void;
 	fileList: FileListItem[];
 	refreshFileList: () => void;
 	onSortToggle: () => void;
@@ -29,9 +29,7 @@ function FileList({onFileSelect, fileList, refreshFileList, onSortToggle, descen
 		}
 
 		const blob = new Blob([response.data.content], {type: "text/plain"});
-
 		const url = URL.createObjectURL(blob);
-
 		const a = document.createElement("a");
 		a.href = url;
 		a.download = file.name;
@@ -63,7 +61,7 @@ function FileList({onFileSelect, fileList, refreshFileList, onSortToggle, descen
 					<button
 						type="button"
 						className="bg-transparent border-0 p-0 text-inherit cursor-pointer hover:underline"
-						onClick={() => onFileSelect(file.id)}
+						onClick={() => onFileSelect(file.id, refreshFileList)}
 					>
 						{file.name}
 					</button>

--- a/frontend/src/fileBrowser/FileList.tsx
+++ b/frontend/src/fileBrowser/FileList.tsx
@@ -22,7 +22,6 @@ function FileList({onFileSelect, fileList, refreshFileList, onSortToggle, descen
 		const response: ApiResponse<Pick<UserFile, "content">> = await apiFetch(`/api/files/${file.id}`);
 
 		if (!response.ok) {
-			console.log(response.error);
 			showToast("error", `${response.error}`);
 			refreshFileList();
 			return;
@@ -46,7 +45,6 @@ function FileList({onFileSelect, fileList, refreshFileList, onSortToggle, descen
 		});
 
 		if (!response.ok) {
-			console.log(response.error);
 			showToast("error", `${response.error}`);
 		} else {
 			showToast("info", "File deleted");

--- a/frontend/src/fileBrowser/FileList.tsx
+++ b/frontend/src/fileBrowser/FileList.tsx
@@ -22,7 +22,7 @@ function FileList({onFileSelect, fileList, refreshFileList, onSortToggle, descen
 		const response: ApiResponse<Pick<UserFile, "content">> = await apiFetch(`/api/files/${file.id}`);
 
 		if (!response.ok) {
-			console.error(response.error);
+			console.log(response.error);
 			showToast("error", `${response.error}`);
 			refreshFileList();
 			return;
@@ -48,7 +48,7 @@ function FileList({onFileSelect, fileList, refreshFileList, onSortToggle, descen
 		});
 
 		if (!response.ok) {
-			console.error(response.error);
+			console.log(response.error);
 			showToast("error", `${response.error}`);
 		} else {
 			showToast("info", "File deleted");

--- a/frontend/src/fileBrowser/FileList.tsx
+++ b/frontend/src/fileBrowser/FileList.tsx
@@ -6,7 +6,7 @@ import {useShowToast} from "#/src/stores/toastStore";
 import Button from "#/src/components/Button";
 
 type fileListProps = {
-	onFileSelect: (fileId: string) => void;
+	onFileSelect: (fileId: string) => Promise<void>;
 	fileList: FileListItem[];
 	refreshFileList: () => void;
 	onSortToggle: () => void;

--- a/frontend/src/fileBrowser/FileList.tsx
+++ b/frontend/src/fileBrowser/FileList.tsx
@@ -6,7 +6,7 @@ import {useShowToast} from "#/src/stores/toastStore";
 import Button from "#/src/components/Button";
 
 type fileListProps = {
-	onFileSelect: (fileId: string, refreshFileList: () => void) => void;
+	onFileSelect: (fileId: string) => void;
 	fileList: FileListItem[];
 	refreshFileList: () => void;
 	onSortToggle: () => void;
@@ -54,6 +54,17 @@ function FileList({onFileSelect, fileList, refreshFileList, onSortToggle, descen
 		refreshFileList();
 	}
 
+	async function selectFile(fileId: string) {
+		try {
+			await onFileSelect(fileId);
+		} catch (err) {
+			if (typeof err === "string" && err) {
+				showToast("error", err);
+			}
+			refreshFileList();
+		}
+	}
+
 	const listItems: JSX.Element[] = fileList.map<JSX.Element>((file: FileListItem) => {
 		return (
 			<tr key={file.id}>
@@ -61,7 +72,7 @@ function FileList({onFileSelect, fileList, refreshFileList, onSortToggle, descen
 					<button
 						type="button"
 						className="bg-transparent border-0 p-0 text-inherit cursor-pointer hover:underline"
-						onClick={() => onFileSelect(file.id, refreshFileList)}
+						onClick={() => selectFile(file.id)}
 					>
 						{file.name}
 					</button>

--- a/frontend/src/fileBrowser/FileList.tsx
+++ b/frontend/src/fileBrowser/FileList.tsx
@@ -58,6 +58,8 @@ function FileList({onFileSelect, fileList, refreshFileList, onSortToggle, descen
 		} catch (err) {
 			if (typeof err === "string" && err) {
 				showToast("error", err);
+			} else if (err instanceof Error) {
+				showToast("error", err.message);
 			}
 			refreshFileList();
 		}

--- a/frontend/src/fileBrowser/FileUpload.tsx
+++ b/frontend/src/fileBrowser/FileUpload.tsx
@@ -21,7 +21,7 @@ function FileUploader({pushToFileList}: {pushToFileList: (file: FileListItem) =>
 			const err = validateFile(f.type, f.size, await f.text(), f.name);
 			if (err) {
 				showToast("error", `File '${f.name}': ${err}`);
-				console.error(`File '${f.name}' is ${err}`);
+				console.log(`File '${f.name}': ${err}`);
 			} else {
 				if (newFilemap.has(f.name)) {
 					showToast("error", `Duplicate file ${f.name}`);
@@ -65,7 +65,7 @@ function FileUploader({pushToFileList}: {pushToFileList: (file: FileListItem) =>
 		});
 
 		if (!response.ok) {
-			console.error(`${response.error}`);
+			console.log(response.error);
 			if (response.error === "Network error") {
 				showToast("error", "Network error: Try to reupload files");
 			} else {

--- a/frontend/src/fileBrowser/FileUpload.tsx
+++ b/frontend/src/fileBrowser/FileUpload.tsx
@@ -27,7 +27,6 @@ function FileUploader({pushToFileList, refreshFileList}: FileUploaderProps) {
 			const err = validateFile(f.type, f.size, await f.text(), f.name);
 			if (err) {
 				showToast("error", `File '${f.name}': ${err}`);
-				console.log(`File '${f.name}': ${err}`);
 			} else {
 				if (newFilemap.has(f.name)) {
 					showToast("error", `Duplicate file ${f.name}`);
@@ -74,14 +73,12 @@ function FileUploader({pushToFileList, refreshFileList}: FileUploaderProps) {
 		});
 
 		if (!response.ok) {
-			console.log(response.error);
 			if (response.error === "Network error") {
 				showToast("error", "Network error: Try to reupload files");
 			} else {
 				showToast("error", response.error);
 			}
 		} else {
-			console.log(`File ${file.name} uploaded`);
 			const listFile: FileListItem = {name: file.name, id: response.data};
 			pushToFileList(listFile);
 		}
@@ -105,24 +102,19 @@ function FileUploader({pushToFileList, refreshFileList}: FileUploaderProps) {
 				</Button>
 			</div>
 			{fileUploads && (
-				<>
-					<table>
-						<thead className="pt-8">
-							<th></th>
-						</thead>
-						<tbody>
-							{fileUploads &&
-								[...fileUploads.values()].map((file) => (
-									<tr key={file.name}>
-										<td className="px-2">{file.name}</td>
-										<td className="text-center">
-											<span className="loader"></span>
-										</td>
-									</tr>
-								))}
-						</tbody>
-					</table>
-				</>
+				<table className="pt-8">
+					<tbody>
+						{fileUploads &&
+							[...fileUploads.values()].map((file) => (
+								<tr key={file.name}>
+									<td className="px-2">{file.name}</td>
+									<td className="text-center">
+										<span className="loader"></span>
+									</td>
+								</tr>
+							))}
+					</tbody>
+				</table>
 			)}
 		</>
 	);

--- a/frontend/src/fileBrowser/FileUpload.tsx
+++ b/frontend/src/fileBrowser/FileUpload.tsx
@@ -6,15 +6,21 @@ import {apiFetch} from "#/src/utils.js";
 import type {ApiResponse, FileListItem} from "#shared/src/types.ts";
 import {validateFile} from "#shared/src/fileValidation";
 
-function FileUploader({pushToFileList}: {pushToFileList: (file: FileListItem) => void}) {
-	const [fileUploads, setFileUploads] = useState<Map<string, File> | null>(null);
+type FileUploaderProps = {
+	pushToFileList: (file: FileListItem) => void;
+	refreshFileList: () => Promise<void>;
+};
 
+function FileUploader({pushToFileList, refreshFileList}: FileUploaderProps) {
+	const [fileUploads, setFileUploads] = useState<Map<string, File> | null>(null);
+	const [uploadOnGoing, setUploadOnGoing] = useState<boolean>(false);
 	const fileInputRef = useRef<HTMLInputElement>(null);
 	const showToast = useShowToast();
 
 	async function handleFileChange(e: React.ChangeEvent<HTMLInputElement>) {
 		if (!e.target.files) return;
 
+		setUploadOnGoing(true);
 		const newFileArray: File[] = [];
 		const newFilemap = fileUploads ?? new Map<string, File>();
 		for (const f of e.target.files) {
@@ -34,9 +40,12 @@ function FileUploader({pushToFileList}: {pushToFileList: (file: FileListItem) =>
 		if (newFilemap.size > 0) setFileUploads(newFilemap);
 		if (fileInputRef.current) fileInputRef.current.value = "";
 
-		for (const f of newFileArray) {
-			uploadFile(f);
-		}
+		const uploads: Promise<void>[] = newFileArray.map(async (f) => {
+			return await uploadFile(f);
+		});
+		await Promise.allSettled(uploads);
+		refreshFileList();
+		setUploadOnGoing(false);
 	}
 
 	async function handleRemove(name: string) {
@@ -53,9 +62,9 @@ function FileUploader({pushToFileList}: {pushToFileList: (file: FileListItem) =>
 	async function uploadFile(file: File) {
 		if (!file) {
 			console.log("Tried to upload non existent file");
-			return {ok: false, error: "Tried to upload non existent file"} as ApiResponse<string>;
+			return Promise.resolve();
 		}
-		showToast("info", `Uploading file ${file.name}`);
+
 		const formData = new FormData();
 		formData.append("file", file);
 
@@ -73,11 +82,12 @@ function FileUploader({pushToFileList}: {pushToFileList: (file: FileListItem) =>
 			}
 		} else {
 			console.log(`File ${file.name} uploaded`);
-			showToast("success", `File ${file.name} uploaded`);
 			const listFile: FileListItem = {name: file.name, id: response.data};
 			pushToFileList(listFile);
 		}
+		await new Promise((r) => setTimeout(r, 15000));
 		handleRemove(file.name);
+		return Promise.resolve();
 	}
 
 	return (
@@ -91,21 +101,29 @@ function FileUploader({pushToFileList}: {pushToFileList: (file: FileListItem) =>
 					multiple
 					onChange={handleFileChange}
 				/>
-				<Button onClick={() => fileInputRef.current?.click()}>Upload Files</Button>
+				<Button
+					disabled={uploadOnGoing}
+					onClick={() => {
+						if (uploadOnGoing) return; // hack
+						fileInputRef.current?.click();
+					}}
+				>
+					Upload Files
+				</Button>
 			</div>
 			{fileUploads && (
 				<>
 					<table>
-						<thead>
-							<th>file(s)</th>
+						<thead className="pt-8">
+							<th></th>
 						</thead>
 						<tbody>
 							{fileUploads &&
 								[...fileUploads.values()].map((file) => (
 									<tr key={file.name}>
-										<td>🗎 {file.name}</td>
+										<td className="px-2">{file.name}</td>
 										<td className="text-center">
-											<Button onClick={() => handleRemove(file.name)}> ☒ </Button>
+											<span className="loader"></span>
 										</td>
 									</tr>
 								))}

--- a/frontend/src/fileBrowser/FileUpload.tsx
+++ b/frontend/src/fileBrowser/FileUpload.tsx
@@ -6,53 +6,53 @@ import {apiFetch} from "#/src/utils.js";
 import type {ApiResponse} from "#shared/src/types.ts";
 import {validateFile} from "#shared/src/fileValidation";
 
+// if uploading
 function FileUploader({refreshFileList}: {refreshFileList: () => void}) {
-	const [fileUploads, setFileUploads] = useState<Array<File> | null>(null);
-	const [UploadInProgress, setUploadInProgress] = useState<boolean>(false);
+	const [fileUploads, setFileUploads] = useState<Map<string, File> | null>(null);
+
 	const fileInputRef = useRef<HTMLInputElement>(null);
 	const showToast = useShowToast();
-
-	function resetInput() {
-		setFileUploads(null);
-		if (fileInputRef.current) fileInputRef.current.value = "";
-	}
 
 	async function handleFileChange(e: React.ChangeEvent<HTMLInputElement>) {
 		if (!e.target.files) return;
 
-		const newFileArray = fileUploads?.slice() ?? new Array<File>();
+		const newFileArray: File[] = [];
+		const newFilemap = fileUploads ?? new Map<string, File>();
 		for (const f of e.target.files) {
 			const err = validateFile(f.type, f.size, await f.text(), f.name);
 			if (err) {
 				showToast("error", `File '${f.name}': ${err}`);
 				console.error(`File '${f.name}' is ${err}`);
 			} else {
-				const index = newFileArray.findIndex((value: File) => value.name === f.name);
-				if (index !== -1) {
-					if (f.lastModified <= newFileArray[index].lastModified) {
-						showToast("error", `Duplicate file ${f.name}`);
-					} else {
-						newFileArray[index] = f;
-						showToast("info", `Updated file ${f.name}`);
-					}
+				if (newFilemap.has(f.name)) {
+					showToast("error", `Duplicate file ${f.name}`);
 				} else {
+					newFilemap.set(f.name, f);
 					newFileArray.push(f);
 				}
 			}
 		}
-
-		if (newFileArray.length > 0) setFileUploads(newFileArray);
+		if (newFilemap.size > 0) setFileUploads(newFilemap);
 		if (fileInputRef.current) fileInputRef.current.value = "";
+
+		for (const f of newFileArray) uploadFile(f);
+
+		// const promises = newFileArray.map(async (file: File) => {
+		// 	await uploadFile(file);
+		// });
+		// await Promise.allSettled(promises);
+		// refreshFileList();
+		// await Promise.allSettled(promises);
+		// resetInput();
 	}
 
 	async function handleRemove(name: string) {
-		if (fileUploads === null) return;
-
 		setFileUploads((prev) => {
 			if (!prev) return null;
+			const result = new Map(prev);
+			result.delete(name);
 
-			const newFileArray = prev.filter((value: File) => value.name !== name);
-			if (newFileArray.length) return newFileArray;
+			if (result.size) return result;
 			else return null;
 		});
 	}
@@ -83,51 +83,10 @@ function FileUploader({refreshFileList}: {refreshFileList: () => void}) {
 			showToast("success", `File ${file.name} uploaded`);
 		}
 		handleRemove(file.name);
+		// @WARN calling this here probably causes many re render when uploads finish at similar times
+		console.log(file.name, "refreshing");
+		refreshFileList();
 		return Promise.resolve();
-	}
-
-	async function uploadDaFiiles(Uploads: File[]) {
-		const promises = Uploads.map(async (file: File) => {
-			await uploadFile(file);
-		});
-		return await Promise.allSettled(promises);
-	}
-
-	// async function uploadDaFiiles(Uploads: File[]) {
-	// 	const uploadStates: Promise<void>[] = [];
-	// 	for (const file of Uploads) {
-	// 		uploadStates.push(
-	// 			uploadFile(file).then((response) => {
-	// 				if (!response.ok) {
-	// 					console.error(`${response.error}`);
-	// 					if (response.error === "Network error") {
-	// 						showToast("error", "Network error: Try to reupload files");
-	// 					} else {
-	// 						showToast("error", response.error);
-	// 					}
-	// 				} else {
-	// 					console.log(`File ${file.name} uploaded`);
-	// 					showToast("success", `File ${file.name} uploaded`);
-	// 				}
-	// 			}),
-	// 		);
-	// 	}
-	// 	return await Promise.all(uploadStates);
-	// }
-
-	async function handleUpload() {
-		if (fileUploads && !UploadInProgress) {
-			setUploadInProgress(true);
-			console.log("Uploading file(s)...", fileUploads);
-			// I think would be better to make the submit button unpressable during this
-			// @NOTE will look into implementing that in the future
-
-			await uploadDaFiiles(fileUploads);
-			await new Promise((r) => setTimeout(r, 10000));
-			setUploadInProgress(false);
-			refreshFileList();
-			resetInput();
-		}
 	}
 
 	return (
@@ -151,7 +110,7 @@ function FileUploader({refreshFileList}: {refreshFileList: () => void}) {
 						</thead>
 						<tbody>
 							{fileUploads &&
-								[...fileUploads].map((file) => (
+								[...fileUploads.values()].map((file) => (
 									<tr key={file.name}>
 										<td>🗎 {file.name}</td>
 										<td className="text-center">
@@ -161,9 +120,6 @@ function FileUploader({refreshFileList}: {refreshFileList: () => void}) {
 								))}
 						</tbody>
 					</table>
-					<Button disabled={UploadInProgress} onClick={() => handleUpload()}>
-						Submit
-					</Button>
 				</>
 			)}
 		</>

--- a/frontend/src/fileBrowser/FileUpload.tsx
+++ b/frontend/src/fileBrowser/FileUpload.tsx
@@ -3,11 +3,10 @@ import Button from "../components/Button";
 import {useShowToast} from "#/src/stores/toastStore";
 import Input from "../components/Input";
 import {apiFetch} from "#/src/utils.js";
-import type {ApiResponse} from "#shared/src/types.ts";
+import type {ApiResponse, FileListItem} from "#shared/src/types.ts";
 import {validateFile} from "#shared/src/fileValidation";
 
-// if uploading
-function FileUploader({refreshFileList}: {refreshFileList: () => void}) {
+function FileUploader({pushToFileList}: {pushToFileList: (file: FileListItem) => void}) {
 	const [fileUploads, setFileUploads] = useState<Map<string, File> | null>(null);
 
 	const fileInputRef = useRef<HTMLInputElement>(null);
@@ -35,15 +34,9 @@ function FileUploader({refreshFileList}: {refreshFileList: () => void}) {
 		if (newFilemap.size > 0) setFileUploads(newFilemap);
 		if (fileInputRef.current) fileInputRef.current.value = "";
 
-		for (const f of newFileArray) uploadFile(f);
-
-		// const promises = newFileArray.map(async (file: File) => {
-		// 	await uploadFile(file);
-		// });
-		// await Promise.allSettled(promises);
-		// refreshFileList();
-		// await Promise.allSettled(promises);
-		// resetInput();
+		for (const f of newFileArray) {
+			uploadFile(f);
+		}
 	}
 
 	async function handleRemove(name: string) {
@@ -81,12 +74,10 @@ function FileUploader({refreshFileList}: {refreshFileList: () => void}) {
 		} else {
 			console.log(`File ${file.name} uploaded`);
 			showToast("success", `File ${file.name} uploaded`);
+			const listFile: FileListItem = {name: file.name, id: response.data};
+			pushToFileList(listFile);
 		}
 		handleRemove(file.name);
-		// @WARN calling this here probably causes many re render when uploads finish at similar times
-		console.log(file.name, "refreshing");
-		refreshFileList();
-		return Promise.resolve();
 	}
 
 	return (

--- a/frontend/src/fileBrowser/FileUpload.tsx
+++ b/frontend/src/fileBrowser/FileUpload.tsx
@@ -85,7 +85,6 @@ function FileUploader({pushToFileList, refreshFileList}: FileUploaderProps) {
 			const listFile: FileListItem = {name: file.name, id: response.data};
 			pushToFileList(listFile);
 		}
-		await new Promise((r) => setTimeout(r, 15000));
 		handleRemove(file.name);
 		return Promise.resolve();
 	}
@@ -101,13 +100,7 @@ function FileUploader({pushToFileList, refreshFileList}: FileUploaderProps) {
 					multiple
 					onChange={handleFileChange}
 				/>
-				<Button
-					disabled={uploadOnGoing}
-					onClick={() => {
-						if (uploadOnGoing) return; // hack
-						fileInputRef.current?.click();
-					}}
-				>
+				<Button disabled={uploadOnGoing} onClick={() => fileInputRef.current?.click()}>
 					Upload Files
 				</Button>
 			</div>

--- a/frontend/src/fileBrowser/FileUpload.tsx
+++ b/frontend/src/fileBrowser/FileUpload.tsx
@@ -8,6 +8,7 @@ import {validateFile} from "#shared/src/fileValidation";
 
 function FileUploader({refreshFileList}: {refreshFileList: () => void}) {
 	const [fileUploads, setFileUploads] = useState<Array<File> | null>(null);
+	const [UploadInProgress, setUploadInProgress] = useState<boolean>(false);
 	const fileInputRef = useRef<HTMLInputElement>(null);
 	const showToast = useShowToast();
 
@@ -47,44 +48,85 @@ function FileUploader({refreshFileList}: {refreshFileList: () => void}) {
 	async function handleRemove(name: string) {
 		if (fileUploads === null) return;
 
-		const newFileArray = fileUploads.filter((value: File) => value.name !== name);
-		if (newFileArray.length) setFileUploads(newFileArray);
-		else resetInput();
+		setFileUploads((prev) => {
+			if (!prev) return null;
+
+			const newFileArray = prev.filter((value: File) => value.name !== name);
+			if (newFileArray.length) return newFileArray;
+			else return null;
+		});
 	}
 
+	async function uploadFile(file: File) {
+		if (!file) {
+			console.log("Tried to upload non existent file");
+			return {ok: false, error: "Tried to upload non existent file"} as ApiResponse<string>;
+		}
+		showToast("info", `Uploading file ${file.name}`);
+		const formData = new FormData();
+		formData.append("file", file);
+
+		const response: ApiResponse<string> = await apiFetch("/api/files", {
+			method: "POST",
+			body: formData,
+		});
+
+		if (!response.ok) {
+			console.error(`${response.error}`);
+			if (response.error === "Network error") {
+				showToast("error", "Network error: Try to reupload files");
+			} else {
+				showToast("error", response.error);
+			}
+		} else {
+			console.log(`File ${file.name} uploaded`);
+			showToast("success", `File ${file.name} uploaded`);
+		}
+		handleRemove(file.name);
+		return Promise.resolve();
+	}
+
+	async function uploadDaFiiles(Uploads: File[]) {
+		const promises = Uploads.map(async (file: File) => {
+			await uploadFile(file);
+		});
+		return await Promise.allSettled(promises);
+	}
+
+	// async function uploadDaFiiles(Uploads: File[]) {
+	// 	const uploadStates: Promise<void>[] = [];
+	// 	for (const file of Uploads) {
+	// 		uploadStates.push(
+	// 			uploadFile(file).then((response) => {
+	// 				if (!response.ok) {
+	// 					console.error(`${response.error}`);
+	// 					if (response.error === "Network error") {
+	// 						showToast("error", "Network error: Try to reupload files");
+	// 					} else {
+	// 						showToast("error", response.error);
+	// 					}
+	// 				} else {
+	// 					console.log(`File ${file.name} uploaded`);
+	// 					showToast("success", `File ${file.name} uploaded`);
+	// 				}
+	// 			}),
+	// 		);
+	// 	}
+	// 	return await Promise.all(uploadStates);
+	// }
+
 	async function handleUpload() {
-		if (fileUploads) {
+		if (fileUploads && !UploadInProgress) {
+			setUploadInProgress(true);
 			console.log("Uploading file(s)...", fileUploads);
 			// I think would be better to make the submit button unpressable during this
 			// @NOTE will look into implementing that in the future
-			showToast("info", "Uploading file(s)...");
 
-			const formData = new FormData();
-			[...fileUploads].forEach((file: File) => {
-				formData.append("file", file);
-			});
-
-			const response: ApiResponse<null> = await apiFetch("/api/files", {
-				method: "POST",
-				body: formData,
-			});
-
-			if (!response.ok) {
-				console.error(`${response.error}`);
-				if (response.error === "Network error") {
-					showToast("error", "Network error: Try to reupload files");
-					resetInput();
-				} else {
-					const errors = response.error.split("\0");
-					errors.forEach((e) => showToast("error", e));
-				}
-				return;
-			}
-
-			resetInput();
+			await uploadDaFiiles(fileUploads);
+			await new Promise((r) => setTimeout(r, 10000));
+			setUploadInProgress(false);
 			refreshFileList();
-			console.log("File(s) uploaded");
-			showToast("success", "File(s) uploaded");
+			resetInput();
 		}
 	}
 
@@ -119,7 +161,9 @@ function FileUploader({refreshFileList}: {refreshFileList: () => void}) {
 								))}
 						</tbody>
 					</table>
-					<Button onClick={() => handleUpload()}>Submit</Button>
+					<Button disabled={UploadInProgress} onClick={() => handleUpload()}>
+						Submit
+					</Button>
 				</>
 			)}
 		</>

--- a/frontend/src/fileBrowser/FileUploader.tsx
+++ b/frontend/src/fileBrowser/FileUploader.tsx
@@ -36,13 +36,18 @@ function FileUploader({pushToFileList, refreshFileList}: FileUploaderProps) {
 				}
 			}
 		}
-		if (newFilemap.size > 0) setFileUploads(newFilemap);
 		if (fileInputRef.current) fileInputRef.current.value = "";
+		if (newFilemap.size <= 0) return;
+
+		setFileUploads(newFilemap);
 
 		const uploads: Promise<void>[] = newFileArray.map(async (f) => {
 			return await uploadFile(f);
 		});
 		await Promise.allSettled(uploads);
+		const msg =
+			newFileArray.length == 1 ? `File ${newFileArray[0].name} uploaded` : `All ${newFileArray.length} uploaded`;
+		showToast("success", msg);
 		refreshFileList();
 		setUploadOnGoing(false);
 	}

--- a/frontend/src/fileBrowser/FileUploader.tsx
+++ b/frontend/src/fileBrowser/FileUploader.tsx
@@ -21,6 +21,7 @@ function FileUploader({pushToFileList, refreshFileList}: FileUploaderProps) {
 		if (!e.target.files) return;
 
 		setUploadOnGoing(true);
+		const fileCount: number = e.target.files.length;
 		const newFileArray: File[] = [];
 		const newFilemap = fileUploads ?? new Map<string, File>();
 		for (const f of e.target.files) {
@@ -40,14 +41,24 @@ function FileUploader({pushToFileList, refreshFileList}: FileUploaderProps) {
 		if (newFilemap.size <= 0) return;
 
 		setFileUploads(newFilemap);
-
-		const uploads: Promise<void>[] = newFileArray.map(async (f) => {
-			return await uploadFile(f);
+		const succesfulUploads: string[] = [];
+		const uploads = newFileArray.map(async (f) => {
+			return await uploadFile(f).then((filename) => {
+				succesfulUploads.push(filename);
+				return;
+			});
 		});
 		await Promise.allSettled(uploads);
-		const msg =
-			newFileArray.length == 1 ? `File ${newFileArray[0].name} uploaded` : `All ${newFileArray.length} uploaded`;
-		showToast("success", msg);
+		console.log(succesfulUploads);
+		if (succesfulUploads.length <= 0) {
+			showToast("error", "All uploads failed");
+		} else if (succesfulUploads.length === 1) {
+			showToast("info", `File ${succesfulUploads[0]} uploaded`);
+		} else if (succesfulUploads.length < fileCount) {
+			showToast("info", `${succesfulUploads.length}/${fileCount} uploads successful`);
+		} else {
+			showToast("success", `All uploads successful`);
+		}
 		refreshFileList();
 		setUploadOnGoing(false);
 	}
@@ -66,7 +77,7 @@ function FileUploader({pushToFileList, refreshFileList}: FileUploaderProps) {
 	async function uploadFile(file: File) {
 		if (!file) {
 			console.log("Tried to upload non existent file");
-			return Promise.resolve();
+			return Promise.reject();
 		}
 
 		const formData = new FormData();
@@ -77,18 +88,19 @@ function FileUploader({pushToFileList, refreshFileList}: FileUploaderProps) {
 			body: formData,
 		});
 
+		handleRemove(file.name);
 		if (!response.ok) {
 			if (response.error === "Network error") {
 				showToast("error", "Network error: Try to reupload files");
 			} else {
 				showToast("error", response.error);
 			}
+			return Promise.reject();
 		} else {
 			const listFile: FileListItem = {name: file.name, id: response.data};
 			pushToFileList(listFile);
+			return Promise.resolve(file.name);
 		}
-		handleRemove(file.name);
-		return Promise.resolve();
 	}
 
 	return (

--- a/frontend/src/fileBrowser/NewFile.tsx
+++ b/frontend/src/fileBrowser/NewFile.tsx
@@ -36,7 +36,12 @@ function NewFile({onFileCreate, refreshFileList}: NewFileProps): JSX.Element {
 		}
 		const fileId = fileResult.data;
 
-		onFileCreate(fileId);
+		try {
+			await onFileCreate(fileId);
+		} catch (err) {
+			showToast("error", `File creation failed: ${err}`);
+			refreshFileList();
+		}
 	}
 
 	return (

--- a/frontend/src/fileBrowser/NewFile.tsx
+++ b/frontend/src/fileBrowser/NewFile.tsx
@@ -5,10 +5,11 @@ import Input from "#/src/components/Input";
 import {apiFetch} from "#/src/utils.ts";
 
 type NewFileProps = {
-	onFileCreate: (fileId: string) => void;
+	onFileCreate: (fileId: string) => Promise<void>;
+	refreshFileList: () => Promise<void>;
 };
 
-function NewFile({onFileCreate}: NewFileProps): JSX.Element {
+function NewFile({onFileCreate, refreshFileList}: NewFileProps): JSX.Element {
 	const [newFilename, setNewFilename] = useState<string>("");
 	const showToast = useShowToast();
 
@@ -30,6 +31,7 @@ function NewFile({onFileCreate}: NewFileProps): JSX.Element {
 
 		if (!fileResult.ok) {
 			showToast("error", `File creation failed: ${fileResult.error}`);
+			refreshFileList();
 			return;
 		}
 		const fileId = fileResult.data;

--- a/frontend/src/fileBrowser/NewFile.tsx
+++ b/frontend/src/fileBrowser/NewFile.tsx
@@ -22,7 +22,7 @@ function NewFile({onFileCreate}: NewFileProps): JSX.Element {
 		const file = new File([""], newFilename!, {type: "text/plain"});
 		formData.append("file", file);
 
-		const fileResult = await apiFetch<string[]>("/api/files", {
+		const fileResult = await apiFetch<string>("/api/files", {
 			method: "POST",
 			body: formData,
 		});
@@ -31,7 +31,7 @@ function NewFile({onFileCreate}: NewFileProps): JSX.Element {
 			showToast("error", `File creation failed: ${fileResult.error}`);
 			return;
 		}
-		const fileId = fileResult.data[0];
+		const fileId = fileResult.data;
 
 		onFileCreate(fileId);
 	}

--- a/frontend/src/fileBrowser/NewFile.tsx
+++ b/frontend/src/fileBrowser/NewFile.tsx
@@ -13,13 +13,14 @@ function NewFile({onFileCreate}: NewFileProps): JSX.Element {
 	const showToast = useShowToast();
 
 	async function openNewFile() {
-		if (newFilename === "") {
+		if (!newFilename || !newFilename.trim().length) {
 			showToast("error", "Filename can't be empty");
 			return;
 		}
 
 		const formData = new FormData();
-		const file = new File([""], newFilename!, {type: "text/plain"});
+		const file = new File([""], newFilename, {type: "text/plain"});
+
 		formData.append("file", file);
 
 		const fileResult = await apiFetch<string>("/api/files", {

--- a/frontend/src/fileBrowser/useFileBrowser.ts
+++ b/frontend/src/fileBrowser/useFileBrowser.ts
@@ -47,6 +47,7 @@ function useFileBrowser() {
 
 	const refreshFileList = useCallback(async () => {
 		const response: ApiResponse<FileListItem[]> = await apiFetch("/api/files");
+		console.log("refreshhhh");
 		if (response.ok) {
 			setFileList(response.data);
 		} else {

--- a/frontend/src/fileBrowser/useFileBrowser.ts
+++ b/frontend/src/fileBrowser/useFileBrowser.ts
@@ -50,7 +50,7 @@ function useFileBrowser() {
 		if (response.ok) {
 			setFileList(response.data);
 		} else {
-			console.error(response.error);
+			console.log(response.error);
 			showToast("error", `${response.error}`);
 		}
 	}, [showToast]);

--- a/frontend/src/fileBrowser/useFileBrowser.ts
+++ b/frontend/src/fileBrowser/useFileBrowser.ts
@@ -1,4 +1,4 @@
-import type {UserFile, ApiResponse} from "#shared/src/types";
+import type {ApiResponse, FileListItem} from "#shared/src/types";
 import {useState, useEffect, useMemo, useCallback} from "react";
 import {apiFetch} from "#/src/utils";
 import {useShowToast} from "#/src/stores/toastStore";
@@ -7,7 +7,7 @@ import {useSearchParams} from "react-router";
 const FILES_PER_PAGE = 10;
 
 function useFileBrowser() {
-	const [fileList, setFileList] = useState<UserFile[] | null>(null);
+	const [fileList, setFileList] = useState<FileListItem[] | null>(null);
 	const [searchParams, setSearchParams] = useSearchParams();
 	const showToast = useShowToast();
 
@@ -38,7 +38,7 @@ function useFileBrowser() {
 			return prev;
 		});
 	}
-	const processed = useMemo<UserFile[]>(() => {
+	const processed = useMemo<FileListItem[]>(() => {
 		if (!fileList) return [];
 		return fileList
 			.filter((f) => f.name.toLocaleLowerCase().includes(filter.toLocaleLowerCase()))
@@ -46,7 +46,7 @@ function useFileBrowser() {
 	}, [fileList, filter, sortDescending]);
 
 	const refreshFileList = useCallback(async () => {
-		const response: ApiResponse<UserFile[]> = await apiFetch("/api/files");
+		const response: ApiResponse<FileListItem[]> = await apiFetch("/api/files");
 		if (response.ok) {
 			setFileList(response.data);
 		} else {
@@ -54,6 +54,10 @@ function useFileBrowser() {
 			showToast("error", `${response.error}`);
 		}
 	}, [showToast]);
+
+	function pushToFileList(file: FileListItem) {
+		setFileList((prev) => prev?.concat(file) ?? [file]);
+	}
 
 	useEffect(() => void refreshFileList(), []);
 
@@ -71,6 +75,7 @@ function useFileBrowser() {
 		sortDescending,
 		toggleSort,
 		refreshFileList,
+		pushToFileList,
 		totalFiles,
 	};
 }

--- a/frontend/src/fileBrowser/useFileBrowser.ts
+++ b/frontend/src/fileBrowser/useFileBrowser.ts
@@ -50,7 +50,6 @@ function useFileBrowser() {
 		if (response.ok) {
 			setFileList(response.data);
 		} else {
-			console.log(response.error);
 			showToast("error", `${response.error}`);
 		}
 	}, [showToast]);

--- a/frontend/src/fileBrowser/useFileBrowser.ts
+++ b/frontend/src/fileBrowser/useFileBrowser.ts
@@ -47,7 +47,6 @@ function useFileBrowser() {
 
 	const refreshFileList = useCallback(async () => {
 		const response: ApiResponse<FileListItem[]> = await apiFetch("/api/files");
-		console.log("refreshhhh");
 		if (response.ok) {
 			setFileList(response.data);
 		} else {

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -84,4 +84,61 @@
 	::-webkit-scrollbar-thumb:hover {
 		border-color: var(--color-canvas);
 	}
+
+	.loader {
+		display: block;
+		position: relative;
+		height: 10px;
+		width: 70px;
+		background-image:
+			linear-gradient(var(--color-foreground) 10px, transparent 0),
+			linear-gradient(var(--color-foreground) 10px, transparent 0),
+			linear-gradient(var(--color-foreground) 10px, transparent 0),
+			linear-gradient(var(--color-foreground) 10px, transparent 0);
+		background-repeat: no-repeat;
+		background-size: 10px auto;
+		background-position:
+			0 0,
+			20px 0,
+			40px 0,
+			60px 0;
+		animation: pgfill 1s linear infinite;
+	}
+	@keyframes pgfill {
+		0% {
+			background-image:
+				linear-gradient(var(--color-foreground) 10px, transparent 0),
+				linear-gradient(var(--color-foreground) 10px, transparent 0),
+				linear-gradient(var(--color-foreground) 10px, transparent 0),
+				linear-gradient(var(--color-foreground) 10px, transparent 0);
+		}
+		25% {
+			background-image:
+				linear-gradient(var(--color-accent) 10px, transparent 0),
+				linear-gradient(var(--color-foreground) 10px, transparent 0),
+				linear-gradient(var(--color-foreground) 10px, transparent 0),
+				linear-gradient(var(--color-foreground) 10px, transparent 0);
+		}
+		50% {
+			background-image:
+				linear-gradient(var(--color-foreground) 10px, transparent 0),
+				linear-gradient(var(--color-accent) 10px, transparent 0),
+				linear-gradient(var(--color-foreground) 10px, transparent 0),
+				linear-gradient(var(--color-foreground) 10px, transparent 0);
+		}
+		75% {
+			background-image:
+				linear-gradient(var(--color-foreground) 10px, transparent 0),
+				linear-gradient(var(--color-foreground) 10px, transparent 0),
+				linear-gradient(var(--color-accent) 10px, transparent 0),
+				linear-gradient(var(--color-foreground) 10px, transparent 0);
+		}
+		100% {
+			background-image:
+				linear-gradient(var(--color-foreground) 10px, transparent 0),
+				linear-gradient(var(--color-foreground) 10px, transparent 0),
+				linear-gradient(var(--color-foreground) 10px, transparent 0),
+				linear-gradient(var(--color-accent) 10px, transparent 0);
+		}
+	}
 }

--- a/shared/src/types.ts
+++ b/shared/src/types.ts
@@ -1,10 +1,11 @@
-// id here for testing
 export type UserFile = {
 	id: string;
 	name: string;
 	content: string;
 	owner_id: number;
 };
+
+export type FileListItem = Pick<UserFile, "id" | "name">;
 
 export type User = {
 	id: number;


### PR DESCRIPTION
* Separates multi file uploads into individual calls
* Change backend upload api to only accept single files
* Adds 'progress indicator' by @EyzeCOLD 
* Add partial type FileListItem to use in the file list 
* Change upload logic to not refresh the file list by calling fetch but just appending to the file list
* Calls refreshFileList once all files have finished uploading
* Disables uploading during an already ongoing upload
* Added call to refreshFileList into most frontend fetch failures 
* Changes some fronted console.errors into console.log
* Fix Button component to include the disabled field

Closes #102
Closes #100 