### PR TITLE
Fix backend's OAuth confirmation redirection

### DIFF
--- a/backend/src/endpoints/oauth.ts
+++ b/backend/src/endpoints/oauth.ts
@@ -199,7 +199,7 @@ function establishSession(req: Request, res: Response, userId: number) {
 		req.session.userId = userId;
 		req.session.save((error) => {
 			if (error) return res.redirect("/login");
-			res.redirect("/dashboard");
+			res.redirect("/filebrowser");
 		});
 	});
 }


### PR DESCRIPTION
Changed from now-gone `dashboard` to `filebrowser`.

Very reviewable PR, I'd say.